### PR TITLE
[Feat] PhotoDetail 차트 구현 등 (#12)

### DIFF
--- a/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
+++ b/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		9ED6912F2D3D57D2007E76E8 /* PhotoTopicResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED6912E2D3D57D2007E76E8 /* PhotoTopicResponseModel.swift */; };
 		9ED691312D3D59E4007E76E8 /* TopicIDType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED691302D3D59E4007E76E8 /* TopicIDType.swift */; };
 		9ED691342D3DCA1A007E76E8 /* DGCharts in Frameworks */ = {isa = PBXBuildFile; productRef = 9ED691332D3DCA1A007E76E8 /* DGCharts */; };
+		9ED6913A2D3DCECC007E76E8 /* Secret.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9ED691392D3DCEC8007E76E8 /* Secret.xcconfig */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -85,6 +86,7 @@
 		9ED691292D3D3BF8007E76E8 /* PhotoTopicCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoTopicCollectionHeaderView.swift; sourceTree = "<group>"; };
 		9ED6912E2D3D57D2007E76E8 /* PhotoTopicResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoTopicResponseModel.swift; sourceTree = "<group>"; };
 		9ED691302D3D59E4007E76E8 /* TopicIDType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicIDType.swift; sourceTree = "<group>"; };
+		9ED691392D3DCEC8007E76E8 /* Secret.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +135,7 @@
 		9E5701242D3BBAFB00D62846 /* Application */ = {
 			isa = PBXGroup;
 			children = (
+				9ED691392D3DCEC8007E76E8 /* Secret.xcconfig */,
 				9E5701132D3BBAF800D62846 /* AppDelegate.swift */,
 				9E57011A2D3BBAF800D62846 /* SceneDelegate.swift */,
 				9E5701152D3BBAF800D62846 /* Info.plist */,
@@ -410,6 +413,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9ED6913A2D3DCECC007E76E8 /* Secret.xcconfig in Resources */,
 				9E57011D2D3BBAF800D62846 /* Assets.xcassets in Resources */,
 				9E57011F2D3BBAF800D62846 /* LaunchScreen.storyboard in Resources */,
 			);

--- a/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
+++ b/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
@@ -477,6 +477,7 @@
 /* Begin XCBuildConfiguration section */
 		9E57010F2D3BBADB00D62846 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9ED691392D3DCEC8007E76E8 /* Secret.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -511,6 +512,7 @@
 		};
 		9E5701102D3BBADB00D62846 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9ED691392D3DCEC8007E76E8 /* Secret.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
+++ b/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		9ED6912A2D3D3BF8007E76E8 /* PhotoTopicCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED691292D3D3BF8007E76E8 /* PhotoTopicCollectionHeaderView.swift */; };
 		9ED6912F2D3D57D2007E76E8 /* PhotoTopicResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED6912E2D3D57D2007E76E8 /* PhotoTopicResponseModel.swift */; };
 		9ED691312D3D59E4007E76E8 /* TopicIDType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED691302D3D59E4007E76E8 /* TopicIDType.swift */; };
+		9ED691342D3DCA1A007E76E8 /* DGCharts in Frameworks */ = {isa = PBXBuildFile; productRef = 9ED691332D3DCA1A007E76E8 /* DGCharts */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -93,6 +94,7 @@
 			files = (
 				9E5701532D3BBD8300D62846 /* Kingfisher in Frameworks */,
 				9E57014A2D3BBD6800D62846 /* SnapKit in Frameworks */,
+				9ED691342D3DCA1A007E76E8 /* DGCharts in Frameworks */,
 				9E5701502D3BBD7A00D62846 /* Then in Frameworks */,
 				9E57014D2D3BBD7200D62846 /* Alamofire in Frameworks */,
 			);
@@ -356,6 +358,7 @@
 				9E57014C2D3BBD7200D62846 /* Alamofire */,
 				9E57014F2D3BBD7A00D62846 /* Then */,
 				9E5701522D3BBD8300D62846 /* Kingfisher */,
+				9ED691332D3DCA1A007E76E8 /* DGCharts */,
 			);
 			productName = PhotoProject;
 			productReference = 9E5700FB2D3BBAD900D62846 /* PhotoProject.app */;
@@ -390,6 +393,7 @@
 				9E57014B2D3BBD7200D62846 /* XCRemoteSwiftPackageReference "Alamofire" */,
 				9E57014E2D3BBD7A00D62846 /* XCRemoteSwiftPackageReference "Then" */,
 				9E5701512D3BBD8300D62846 /* XCRemoteSwiftPackageReference "Kingfisher" */,
+				9ED691322D3DCA1A007E76E8 /* XCRemoteSwiftPackageReference "Charts" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 9E5700FC2D3BBAD900D62846 /* Products */;
@@ -710,6 +714,14 @@
 				minimumVersion = 8.1.3;
 			};
 		};
+		9ED691322D3DCA1A007E76E8 /* XCRemoteSwiftPackageReference "Charts" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ChartsOrg/Charts.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.1.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -732,6 +744,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9E5701512D3BBD8300D62846 /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
+		};
+		9ED691332D3DCA1A007E76E8 /* DGCharts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9ED691322D3DCA1A007E76E8 /* XCRemoteSwiftPackageReference "Charts" */;
+			productName = DGCharts;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/PhotoProject/PhotoProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PhotoProject/PhotoProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d99f40bf337ce2a4bce76bc77cb66906b6687d29d67e595f67b26212bb9d4e7c",
+  "originHash" : "17de6b03bd8f2a27d96d2b539ac456f4a87af1030865bb3cdcb254657c288a47",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
         "version" : "5.10.2"
+      }
+    },
+    {
+      "identity" : "charts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChartsOrg/Charts.git",
+      "state" : {
+        "revision" : "dd9c72e3d7e751e769971092a6bd72d39198ae63",
+        "version" : "5.1.0"
       }
     },
     {

--- a/PhotoProject/PhotoProject/Application/Info.plist
+++ b/PhotoProject/PhotoProject/Application/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CLIENT_ID</key>
+	<string>$(CLIENT_ID)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/PhotoProject/PhotoProject/Application/Secret.xcconfig
+++ b/PhotoProject/PhotoProject/Application/Secret.xcconfig
@@ -1,0 +1,8 @@
+//
+//  Secret.xcconfig
+//  PhotoProject
+//
+//  Created by 박신영 on 1/20/25.
+//
+
+ClIENT_ID = VNUJ0jFTejoTUtVv7AwX

--- a/PhotoProject/PhotoProject/Application/Secret.xcconfig
+++ b/PhotoProject/PhotoProject/Application/Secret.xcconfig
@@ -5,4 +5,4 @@
 //  Created by 박신영 on 1/20/25.
 //
 
-ClIENT_ID = VNUJ0jFTejoTUtVv7AwX
+CLIENT_ID = qky6eUPqTsK4jy8oaYfp8vaxWwoIHzuH5gPWhivTFTA

--- a/PhotoProject/PhotoProject/Global/Extension/Bundle+Extension.swift
+++ b/PhotoProject/PhotoProject/Global/Extension/Bundle+Extension.swift
@@ -9,8 +9,8 @@ import Foundation
 
 extension Bundle {
     
-    var apiKey: String? {
-        return infoDictionary?["API_KEY"] as? String
+    var client_id: String? {
+        return infoDictionary?["CLIENT_ID"] as? String
     }
     
 }

--- a/PhotoProject/PhotoProject/Global/Utils/DateFormatterManager.swift
+++ b/PhotoProject/PhotoProject/Global/Utils/DateFormatterManager.swift
@@ -16,14 +16,18 @@ final class DateFormatterManager {
     
     let dateFormatter = DateFormatter()
     
-    func setDateInTravelTalk(strDate: String) -> String {
+    func setDateString(strDate: String, format: String) -> String {
         let inputDate = DateFormatter()
+        inputDate.dateFormat = "yyyy-MM-dd"
         let date = inputDate.date(from: strDate)
         
         let outputDate = DateFormatter()
-        outputDate.dateFormat = "yy.MM.dd"
-        
-        return outputDate.string(from: date ?? Date())
+        outputDate.dateFormat = format
+        guard let date else {
+            print("setDateString error")
+            return ""
+        }
+        return outputDate.string(from: date)
     }
     
     func setDateInChat(strDate: String) -> String {

--- a/PhotoProject/PhotoProject/Network/NetworkManager.swift
+++ b/PhotoProject/PhotoProject/Network/NetworkManager.swift
@@ -15,6 +15,8 @@ class NetworkManager {
     
     private init() {}
     
+    
+    
     func getPhotoSearchAPI(query: String,
                            page: Int,
                            perPage: Int,

--- a/PhotoProject/PhotoProject/Network/NetworkManager.swift
+++ b/PhotoProject/PhotoProject/Network/NetworkManager.swift
@@ -15,8 +15,6 @@ class NetworkManager {
     
     private init() {}
     
-    
-    
     func getPhotoSearchAPI(query: String,
                            page: Int,
                            perPage: Int,
@@ -24,9 +22,11 @@ class NetworkManager {
                            color: String? = nil,
                            complitionHandler: @escaping (PhotoSearchResponseModel, Int) -> (Void))
     {
+        guard let clientID = Bundle.main.client_id else {return}
         let url = "https://api.unsplash.com/search/photos"
         let method: HTTPMethod = .get
-        var parameters: [String: Any] = ["query": query, "page": page, "per_page": perPage, "order_by": orderBy, "client_id": "qky6eUPqTsK4jy8oaYfp8vaxWwoIHzuH5gPWhivTFTA"]
+        var parameters: [String: Any] = ["query": query, "page": page, "per_page": perPage, "order_by": orderBy, "client_id": clientID]
+        
         
         switch color != nil {
         case true:
@@ -53,9 +53,10 @@ class NetworkManager {
     func getPhotoDetailAPI(imageID: String,
                            complitionHandler: @escaping (PhotoDetailResponseModel, Int) -> (Void))
     {
+        guard let clientID = Bundle.main.client_id else {return}
         let url = "https://api.unsplash.com/photos/\(imageID)/statistics"
         let method: HTTPMethod = .get
-        let parameters: [String: Any] = ["client_id": "qky6eUPqTsK4jy8oaYfp8vaxWwoIHzuH5gPWhivTFTA"]
+        let parameters: [String: Any] = ["client_id": clientID]
         
         print("parameters : \(parameters)")
         
@@ -74,9 +75,12 @@ class NetworkManager {
     func getPhotoTopicAPI(topicID: String,
                           complitionHandler: @escaping ([PhotoTopicResponseModel], Int) -> (Void))
     {
+        guard let clientID = Bundle.main.client_id else {return}
         let url = "https://api.unsplash.com/topics/\(topicID)/photos"
         let method: HTTPMethod = .get
-        let parameters: [String: Any] = ["client_id": "qky6eUPqTsK4jy8oaYfp8vaxWwoIHzuH5gPWhivTFTA"]
+        let parameters: [String: Any] = ["client_id": clientID]
+        print("clientID :",clientID)
+        
         
         AF.request(url, method: method, parameters: parameters).responseDecodable(of: [PhotoTopicResponseModel].self) { response in
             switch response.result {

--- a/PhotoProject/PhotoProject/Network/PhotoSearch/PhotoSearchResponseModel.swift
+++ b/PhotoProject/PhotoProject/Network/PhotoSearch/PhotoSearchResponseModel.swift
@@ -31,7 +31,7 @@ struct Result: Decodable {
 
 // MARK: - Urls
 struct Urls: Decodable {
-    let raw, small, thumb: String
+    let raw, small, thumb, regular: String
 }
 
 // MARK: - User
@@ -56,7 +56,7 @@ struct DummyDataGenerator {
                 color: ["#FF5733", "#33FF57", "#3357FF", "#F0F0F0", "#000000"].randomElement()!,
                 urls: Urls(
                     raw: "star",
-                    small: "star", thumb: "star"
+                    small: "star", thumb: "star", regular: "star"
                 ),
                 likes: Int.random(in: 0...1000),
                 user: User(

--- a/PhotoProject/PhotoProject/Network/PhotoSearch/PhotoSearchResponseModel.swift
+++ b/PhotoProject/PhotoProject/Network/PhotoSearch/PhotoSearchResponseModel.swift
@@ -44,34 +44,3 @@ struct User: Decodable {
 struct ProfileImage: Decodable {
     let medium: String
 }
-
-struct DummyDataGenerator {
-    static func generateDummyData() -> PhotoSearchResponseModel {
-        let results = (1...20).map { index in
-            Result(
-                id: "id_\(index)",
-                created_at: "2025-01-19T12:00:00Z",
-                width: Int.random(in: 800...4000),
-                height: Int.random(in: 800...4000),
-                color: ["#FF5733", "#33FF57", "#3357FF", "#F0F0F0", "#000000"].randomElement()!,
-                urls: Urls(
-                    raw: "star",
-                    small: "star", thumb: "star", regular: "star"
-                ),
-                likes: Int.random(in: 0...1000),
-                user: User(
-                    name: "User \(index)",
-                    profile_image: ProfileImage(
-                        medium: "star"
-                    )
-                )
-            )
-        }
-        
-        return PhotoSearchResponseModel(
-            total: 20,
-            totalPages: 1,
-            results: results
-        )
-    }
-}

--- a/PhotoProject/PhotoProject/Network/PhotoSearch/PhotoSearchResponseModel.swift
+++ b/PhotoProject/PhotoProject/Network/PhotoSearch/PhotoSearchResponseModel.swift
@@ -31,7 +31,7 @@ struct Result: Decodable {
 
 // MARK: - Urls
 struct Urls: Decodable {
-    let raw, small: String
+    let raw, small, thumb: String
 }
 
 // MARK: - User
@@ -56,7 +56,7 @@ struct DummyDataGenerator {
                 color: ["#FF5733", "#33FF57", "#3357FF", "#F0F0F0", "#000000"].randomElement()!,
                 urls: Urls(
                     raw: "star",
-                    small: "star"
+                    small: "star", thumb: "star"
                 ),
                 likes: Int.random(in: 0...1000),
                 user: User(

--- a/PhotoProject/PhotoProject/Present/PhotoDetail/Model/PhotoDetailModel.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoDetail/Model/PhotoDetailModel.swift
@@ -15,4 +15,6 @@ struct PhotoDetailModel {
     let selectedImageWidth, selectedImageHeight: Int
     let downloadCount: Int
     let viewCount: Int
+    let day30ViewCount: [Int]
+    let day30DownCount: [Int]
 }

--- a/PhotoProject/PhotoProject/Present/PhotoDetail/Model/PhotoDetailModel.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoDetail/Model/PhotoDetailModel.swift
@@ -15,6 +15,18 @@ struct PhotoDetailModel {
     let selectedImageWidth, selectedImageHeight: Int
     let downloadCount: Int
     let viewCount: Int
-    let day30ViewCount: [Int]
-    let day30DownCount: [Int]
+    let monthViewTotalCount: [Int]
+    let monthDownloadTotalCount: [Int]
+    let monthView: MonthView
+    let monthDownload: MonthDownload
+}
+
+struct MonthView {
+    let monthViewDates: [String]
+    let monthViewValues: [Int]
+}
+
+struct MonthDownload {
+    let monthDownloadDates: [String]
+    let monthDownloadValues: [Int]
 }

--- a/PhotoProject/PhotoProject/Present/PhotoDetail/PhotoDetailViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoDetail/PhotoDetailViewController.swift
@@ -10,29 +10,23 @@ import DGCharts
 
 final class PhotoDetailViewController: BaseViewController {
     
-    private let mainView = PhotoDetailView()
     var photoDetailModel: PhotoDetailModel?
     
-//    lazy var graphArray = Array(repeating: "", count: photoDetailModel?.day30DownCount.count ?? 0)
-    var graphArray: [String] = ["09시", "10시", "11시", "12시", "13시", "14시", "15시", "16시", "17시", "18시"]
-
-    let barUnitsSold = [10.0, 17.0, 9.0, 1.0, 8.0, 13.0, 16.0, 14.0, 7.0, 1.0]
-    let lineUnitsSold = [10.0, 18.0, 7.0, 1.0, 5.0, 15.0, 14.0, 17.0, 7.0, 1.0]
+    private let mainView = PhotoDetailView()
     
     override func loadView() {
         view = mainView
-        print(#function)
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        guard let photoDetailModel else {return}
+        guard let photoDetailModel
+        else {return}
         DispatchQueue.main.async {
             self.mainView.setDataUI(photoDetailModel: photoDetailModel)
-            print(#function)
+            self.setChart(title: "한달 조회 수", dataPoints: photoDetailModel.monthView.monthViewDates, lineValues: photoDetailModel.monthView.monthViewValues)
         }
-        print(#function)
     }
 
     override func viewDidLoad() {
@@ -40,44 +34,9 @@ final class PhotoDetailViewController: BaseViewController {
 
         setNavUI()
         setAddtarget()
-        setChart(dataPoints: graphArray, barValues: barUnitsSold, lineValues: lineUnitsSold)
-        print(#function)
     }
     
-    func setChart(dataPoints: [String], barValues: [Double], lineValues: [Double]) {
-        var barDataEntries: [BarChartDataEntry] = []
-        var lineDataEntries: [ChartDataEntry] = []
-                
-        for i in 0..<dataPoints.count {
-            let barDataEntry = BarChartDataEntry(x: Double(i), y: barValues[i])
-            let lineDataEntry = ChartDataEntry(x: Double(i), y: lineValues[i])
-            barDataEntries.append(barDataEntry)
-            lineDataEntries.append(lineDataEntry)
-        }
-
-        let barChartDataSet = BarChartDataSet(entries: barDataEntries, label: "")
-        let lineChartDataSet = LineChartDataSet(entries: lineDataEntries, label: "")
-        
-        lineChartDataSet.colors = [.blue]
-        lineChartDataSet.circleColors = [.white]
-
-        let data: CombinedChartData = CombinedChartData()
-
-        // bar 데이터 지정
-        data.barData = BarChartData(dataSet: barChartDataSet)
-        // line 데이터 지정
-        data.lineData = LineChartData(dataSet: lineChartDataSet)
-        
-        lineChartDataSet.mode = .cubicBezier
-
-        // 콤비 데이터 지정
-        mainView.combinedChartView.data = data
-        
-        mainView.combinedChartView.do {
-            $0.xAxis.valueFormatter = IndexAxisValueFormatter(values: graphArray)
-            $0.animate(xAxisDuration: 2.0, yAxisDuration: 2.0)
-        }
-    }
+    
 
 }
 
@@ -97,6 +56,36 @@ private extension PhotoDetailViewController {
         mainView.chartSegmentedControl.addTarget(self, action: #selector(segmentedControlTapped), for: .valueChanged)
     }
     
+    func setChart(title: String, dataPoints: [String], lineValues: [Int]) {
+        var lineDataEntries: [ChartDataEntry] = []
+                
+        for i in 0..<dataPoints.count {
+            let lineDataEntry = ChartDataEntry(x: Double(i), y: Double(lineValues[i]))
+            lineDataEntries.append(lineDataEntry)
+        }
+
+        let lineChartDataSet = LineChartDataSet(entries: lineDataEntries, label: title)
+        
+        lineChartDataSet.colors = [.cyan]
+        lineChartDataSet.circleColors = [.blue]
+
+        let data: CombinedChartData = CombinedChartData()
+        
+        data.lineData = LineChartData(dataSet: lineChartDataSet)
+        
+        lineChartDataSet.mode = .cubicBezier
+        lineChartDataSet.circleHoleRadius = 2.0
+        lineChartDataSet.circleRadius = 3
+
+        // 콤비 데이터 지정
+        mainView.combinedChartView.data = data
+        
+        mainView.combinedChartView.do {
+            $0.animate(xAxisDuration: 2.0, yAxisDuration: 2.0)
+            $0.backgroundColor = .clear
+        }
+    }
+    
 }
 
 //MARK: - @objc private extension
@@ -109,9 +98,19 @@ private extension PhotoDetailViewController {
     
     @objc
     func segmentedControlTapped(_ sender: UISegmentedControl) {
-        print(#function)
-        sender.selectedSegmentIndex = (sender.selectedSegmentIndex == 0)
-        ? 1 : 0
+        guard let monthView = photoDetailModel?.monthView,
+              let monthDownload = photoDetailModel?.monthDownload
+        else { return print("segmentedControlTapped") }
+        
+        switch sender.selectedSegmentIndex {
+        case 0:
+            print("000")
+            self.setChart(title: "한달 조회 수", dataPoints: monthView.monthViewDates, lineValues: monthView.monthViewValues)
+        case 1:
+            print("111")
+            self.setChart(title: "한달 다운로드 수", dataPoints: monthDownload.monthDownloadDates, lineValues: monthDownload.monthDownloadValues)
+        default: return
+        }
     }
     
 }

--- a/PhotoProject/PhotoProject/Present/PhotoDetail/PhotoDetailViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoDetail/PhotoDetailViewController.swift
@@ -13,20 +13,26 @@ final class PhotoDetailViewController: BaseViewController {
     private let mainView = PhotoDetailView()
     var photoDetailModel: PhotoDetailModel?
     
-    lazy var graphArray = Array(repeating: "", count: photoDetailModel?.day30DownCount.count ?? 0)
+//    lazy var graphArray = Array(repeating: "", count: photoDetailModel?.day30DownCount.count ?? 0)
+    var graphArray: [String] = ["09시", "10시", "11시", "12시", "13시", "14시", "15시", "16시", "17시", "18시"]
 
     let barUnitsSold = [10.0, 17.0, 9.0, 1.0, 8.0, 13.0, 16.0, 14.0, 7.0, 1.0]
     let lineUnitsSold = [10.0, 18.0, 7.0, 1.0, 5.0, 15.0, 14.0, 17.0, 7.0, 1.0]
     
     override func loadView() {
         view = mainView
+        print(#function)
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         guard let photoDetailModel else {return}
-        mainView.setDataUI(photoDetailModel: photoDetailModel)
+        DispatchQueue.main.async {
+            self.mainView.setDataUI(photoDetailModel: photoDetailModel)
+            print(#function)
+        }
+        print(#function)
     }
 
     override func viewDidLoad() {
@@ -35,6 +41,7 @@ final class PhotoDetailViewController: BaseViewController {
         setNavUI()
         setAddtarget()
         setChart(dataPoints: graphArray, barValues: barUnitsSold, lineValues: lineUnitsSold)
+        print(#function)
     }
     
     func setChart(dataPoints: [String], barValues: [Double], lineValues: [Double]) {

--- a/PhotoProject/PhotoProject/Present/PhotoDetail/PhotoDetailViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoDetail/PhotoDetailViewController.swift
@@ -6,11 +6,17 @@
 //
 
 import UIKit
+import DGCharts
 
 final class PhotoDetailViewController: BaseViewController {
     
     private let mainView = PhotoDetailView()
     var photoDetailModel: PhotoDetailModel?
+    
+    lazy var graphArray = Array(repeating: "", count: photoDetailModel?.day30DownCount.count ?? 0)
+
+    let barUnitsSold = [10.0, 17.0, 9.0, 1.0, 8.0, 13.0, 16.0, 14.0, 7.0, 1.0]
+    let lineUnitsSold = [10.0, 18.0, 7.0, 1.0, 5.0, 15.0, 14.0, 17.0, 7.0, 1.0]
     
     override func loadView() {
         view = mainView
@@ -28,6 +34,42 @@ final class PhotoDetailViewController: BaseViewController {
 
         setNavUI()
         setAddtarget()
+        setChart(dataPoints: graphArray, barValues: barUnitsSold, lineValues: lineUnitsSold)
+    }
+    
+    func setChart(dataPoints: [String], barValues: [Double], lineValues: [Double]) {
+        var barDataEntries: [BarChartDataEntry] = []
+        var lineDataEntries: [ChartDataEntry] = []
+                
+        for i in 0..<dataPoints.count {
+            let barDataEntry = BarChartDataEntry(x: Double(i), y: barValues[i])
+            let lineDataEntry = ChartDataEntry(x: Double(i), y: lineValues[i])
+            barDataEntries.append(barDataEntry)
+            lineDataEntries.append(lineDataEntry)
+        }
+
+        let barChartDataSet = BarChartDataSet(entries: barDataEntries, label: "")
+        let lineChartDataSet = LineChartDataSet(entries: lineDataEntries, label: "")
+        
+        lineChartDataSet.colors = [.blue]
+        lineChartDataSet.circleColors = [.white]
+
+        let data: CombinedChartData = CombinedChartData()
+
+        // bar 데이터 지정
+        data.barData = BarChartData(dataSet: barChartDataSet)
+        // line 데이터 지정
+        data.lineData = LineChartData(dataSet: lineChartDataSet)
+        
+        lineChartDataSet.mode = .cubicBezier
+
+        // 콤비 데이터 지정
+        mainView.combinedChartView.data = data
+        
+        mainView.combinedChartView.do {
+            $0.xAxis.valueFormatter = IndexAxisValueFormatter(values: graphArray)
+            $0.animate(xAxisDuration: 2.0, yAxisDuration: 2.0)
+        }
     }
 
 }

--- a/PhotoProject/PhotoProject/Present/PhotoDetail/View/PhotoDetailView.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoDetail/View/PhotoDetailView.swift
@@ -44,6 +44,7 @@ final class PhotoDetailView: BaseView {
     lazy var combinedChartView = CombinedChartView()
     
     override init(frame: CGRect) {
+        
         super.init(frame: frame)
     }
     
@@ -71,7 +72,172 @@ final class PhotoDetailView: BaseView {
                                       chartSegmentedControl)
     }
     
-    override func setLayout() {
+//    override func setLayout() {
+//        underLineView.snp.makeConstraints {
+//            $0.top.equalTo(safeAreaLayoutGuide)
+//            $0.horizontalEdges.equalToSuperview()
+//            $0.height.equalTo(0.6)
+//        }
+//        
+//        scrollView.snp.makeConstraints {
+//            $0.width.equalToSuperview()
+//            $0.top.equalTo(underLineView.snp.bottom).offset(2)
+//            $0.bottom.equalToSuperview()
+//        }
+//        
+//        contentView.snp.makeConstraints {
+//            $0.width.equalTo(scrollView.snp.width)
+//            $0.verticalEdges.equalTo(scrollView)
+//        }
+//        
+//        profileContainerView.snp.makeConstraints {
+//            $0.top.equalTo(underLineView.snp.bottom).offset(2)
+//            $0.leading.equalToSuperview().offset(15)
+//            $0.width.greaterThanOrEqualTo(40)
+//            $0.height.equalTo(50)
+//        }
+//        
+//        profileImageView.snp.makeConstraints {
+//            $0.leading.equalToSuperview()
+//            $0.centerY.equalToSuperview()
+//            $0.size.equalTo(35)
+//        }
+//        
+//        creatAtLabel.snp.makeConstraints {
+//            $0.leading.equalTo(profileImageView.snp.trailing).offset(10)
+//            $0.bottom.equalTo(profileImageView.snp.bottom)
+//            $0.trailing.equalToSuperview()
+//        }
+//        
+//        nameLabel.snp.makeConstraints {
+//            $0.leading.equalTo(creatAtLabel.snp.leading)
+//            $0.bottom.equalTo(creatAtLabel.snp.top).offset(-2)
+//            $0.trailing.equalTo(creatAtLabel.snp.trailing)
+//        }
+//        
+//        heartBtn.snp.makeConstraints {
+//            $0.centerY.equalTo(profileImageView.snp.centerY)
+//            $0.trailing.equalToSuperview().offset(-15)
+//            $0.width.equalTo(30)
+//            $0.height.equalTo(28)
+//        }
+//        
+//        mainPosterImage.snp.makeConstraints {
+//            $0.top.equalTo(profileContainerView.snp.bottom)
+//            $0.horizontalEdges.equalToSuperview()
+//        }
+//        
+//        infoContainerView.snp.makeConstraints {
+//            $0.top.equalTo(mainPosterImage.snp.bottom).offset(15)
+//            $0.horizontalEdges.equalToSuperview().inset(15)
+//        }
+//        
+//        infoLabel.snp.makeConstraints {
+//            $0.top.leading.equalToSuperview()
+//        }
+//        
+//        sizeLabel.snp.makeConstraints {
+//            $0.bottom.equalTo(infoLabel.snp.bottom)
+//            $0.leading.equalTo(infoLabel.snp.trailing).offset(100)
+//        }
+//        
+//        sizeNumLabel.snp.makeConstraints {
+//            $0.bottom.equalTo(sizeLabel.snp.bottom)
+//            $0.trailing.equalToSuperview()
+//        }
+//        
+//        viewLabel.snp.makeConstraints {
+//            $0.top.equalTo(sizeLabel.snp.bottom).offset(10)
+//            $0.leading.equalTo(sizeLabel.snp.leading)
+//        }
+//        
+//        viewNumLabel.snp.makeConstraints {
+//            $0.bottom.equalTo(viewLabel.snp.bottom)
+//            $0.trailing.equalToSuperview()
+//        }
+//        
+//        downloadLabel.snp.makeConstraints {
+//            $0.top.equalTo(viewLabel.snp.bottom).offset(10)
+//            $0.leading.equalTo(sizeLabel.snp.leading)
+//        }
+//        
+//        downloadNumLabel.snp.makeConstraints {
+//            $0.bottom.equalTo(downloadLabel.snp.bottom)
+//            $0.trailing.equalToSuperview()
+//        }
+//        
+//        chartLabel.snp.makeConstraints {
+//            $0.top.equalTo(downloadLabel.snp.bottom).offset(50)
+//            $0.leading.equalTo(infoLabel.snp.leading)
+//        }
+//        
+//        chartSegmentedControl.snp.makeConstraints {
+//            $0.leading.equalTo(sizeLabel.snp.leading)
+//            $0.bottom.equalTo(chartLabel.snp.bottom)
+//        }
+//        
+//        combinedChartView.snp.makeConstraints {
+//            $0.top.equalTo(chartSegmentedControl.snp.bottom).offset(10)
+//            $0.leading.equalTo(sizeLabel.snp.leading)
+//            $0.trailing.equalToSuperview().offset(-15)
+//            $0.height.equalTo(300)
+//        }
+//        print(#function, "setLayout 종료")
+//        
+//    }
+    
+    override func setStyle() {
+        underLineView.backgroundColor = .lightGray
+        
+        profileImageView.do {
+            $0.image = UIImage(systemName: "star")
+            $0.layer.cornerRadius = 40/2
+            $0.contentMode = .scaleAspectFill
+        }
+        
+        nameLabel.setLabelUI("name", font: .systemFont(ofSize: 16, weight: .light))
+        
+        creatAtLabel.setLabelUI("2888년 8월 8일 게시됨", font: .systemFont(ofSize: 12, weight: .medium))
+        
+        heartBtn.do {
+            $0.setImage(UIImage(systemName: "heart.fill"), for: .normal)
+            $0.backgroundColor = .clear
+            $0.imageView?.snp.makeConstraints {
+                $0.edges.equalToSuperview()
+            }
+        }
+        
+        mainPosterImage.do {
+            $0.image = UIImage(systemName: "person")
+            $0.contentMode = .scaleAspectFill
+        }
+        
+        infoLabel.setLabelUI("정보", font: .systemFont(ofSize: 18, weight: .heavy))
+        
+        sizeLabel.setLabelUI("크기", font: .systemFont(ofSize: 14, weight: .bold))
+        viewLabel.setLabelUI("조회수", font: .systemFont(ofSize: 14, weight: .bold))
+        downloadLabel.setLabelUI("다운로드", font: .systemFont(ofSize: 14, weight: .bold))
+        
+        sizeNumLabel.setLabelUI("3000 x 3999", font: .systemFont(ofSize: 12, weight: .light))
+        viewNumLabel.setLabelUI(214912894.formatted(), font: .systemFont(ofSize: 12, weight: .light))
+        downloadNumLabel.setLabelUI(12481294.formatted(), font: .systemFont(ofSize: 12, weight: .light))
+        
+        chartLabel.setLabelUI("차트", font: .systemFont(ofSize: 18, weight: .heavy))
+        
+        chartSegmentedControl.do {
+            $0.selectedSegmentIndex = 0
+            $0.isEnabled = true
+            $0.isUserInteractionEnabled = true
+        }
+        
+        combinedChartView.do {
+            $0.backgroundColor = .blue
+        }
+    }
+    
+    func setDataUI(photoDetailModel: PhotoDetailModel) {
+        //view.setLayout이 처음 불리는 시점에는 self.view의 width와 height의 크기가 결정되지 않았었음, 왜냐?! vc의 viewDidLoad가 실행되기 이전에 이미 view.setLayout함수는 끝이 나니까
+        
         underLineView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
             $0.horizontalEdges.equalToSuperview()
@@ -182,58 +348,6 @@ final class PhotoDetailView: BaseView {
             $0.height.equalTo(300)
         }
         
-    }
-    
-    override func setStyle() {
-        underLineView.backgroundColor = .lightGray
-        
-        profileImageView.do {
-            $0.image = UIImage(systemName: "star")
-            $0.layer.cornerRadius = 40/2
-            $0.contentMode = .scaleAspectFill
-        }
-        
-        nameLabel.setLabelUI("name", font: .systemFont(ofSize: 16, weight: .light))
-        
-        creatAtLabel.setLabelUI("2888년 8월 8일 게시됨", font: .systemFont(ofSize: 12, weight: .medium))
-        
-        heartBtn.do {
-            $0.setImage(UIImage(systemName: "heart.fill"), for: .normal)
-            $0.backgroundColor = .clear
-            $0.imageView?.snp.makeConstraints {
-                $0.edges.equalToSuperview()
-            }
-        }
-        
-        mainPosterImage.do {
-            $0.image = UIImage(systemName: "person")
-            $0.contentMode = .scaleAspectFill
-        }
-        
-        infoLabel.setLabelUI("정보", font: .systemFont(ofSize: 18, weight: .heavy))
-        
-        sizeLabel.setLabelUI("크기", font: .systemFont(ofSize: 14, weight: .bold))
-        viewLabel.setLabelUI("조회수", font: .systemFont(ofSize: 14, weight: .bold))
-        downloadLabel.setLabelUI("다운로드", font: .systemFont(ofSize: 14, weight: .bold))
-        
-        sizeNumLabel.setLabelUI("3000 x 3999", font: .systemFont(ofSize: 12, weight: .light))
-        viewNumLabel.setLabelUI(214912894.formatted(), font: .systemFont(ofSize: 12, weight: .light))
-        downloadNumLabel.setLabelUI(12481294.formatted(), font: .systemFont(ofSize: 12, weight: .light))
-        
-        chartLabel.setLabelUI("차트", font: .systemFont(ofSize: 18, weight: .heavy))
-        
-        chartSegmentedControl.do {
-            $0.selectedSegmentIndex = 0
-            $0.isEnabled = true
-            $0.isUserInteractionEnabled = true
-        }
-        
-        combinedChartView.do {
-            $0.backgroundColor = .blue
-        }
-    }
-    
-    func setDataUI(photoDetailModel: PhotoDetailModel) {
         mainPosterImage.setImageKfDownSampling(with: photoDetailModel.selectedImageURL, cornerRadius: 0)
         profileImageView.setImageKfDownSampling(with: photoDetailModel.profileImageURL, cornerRadius: 40/2)
         nameLabel.text = photoDetailModel.profileName

--- a/PhotoProject/PhotoProject/Present/PhotoDetail/View/PhotoDetailView.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoDetail/View/PhotoDetailView.swift
@@ -124,23 +124,20 @@ final class PhotoDetailView: BaseView {
         mainPosterImage.snp.makeConstraints {
             $0.top.equalTo(profileContainerView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(400)
         }
         
         infoContainerView.snp.makeConstraints {
             $0.top.equalTo(mainPosterImage.snp.bottom).offset(15)
             $0.horizontalEdges.equalToSuperview().inset(15)
-            //            $0.height.greaterThanOrEqualTo(40)
         }
         
         infoLabel.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
-            $0.width.equalTo(100)
         }
         
         sizeLabel.snp.makeConstraints {
             $0.bottom.equalTo(infoLabel.snp.bottom)
-            $0.leading.equalTo(infoLabel.snp.trailing)
+            $0.leading.equalTo(infoLabel.snp.trailing).offset(100)
         }
         
         sizeNumLabel.snp.makeConstraints {

--- a/PhotoProject/PhotoProject/Present/PhotoDetail/View/PhotoDetailView.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoDetail/View/PhotoDetailView.swift
@@ -26,6 +26,7 @@ final class PhotoDetailView: BaseView {
     private let heartBtn = UIButton()
     
     private let mainPosterImage = UIImageView()
+    
     private let infoContainerView = UIView()
     private let infoLabel = UILabel()
     private let sizeLabel = UILabel()
@@ -36,17 +37,8 @@ final class PhotoDetailView: BaseView {
     private let downloadNumLabel = UILabel()
     
     private let chartLabel = UILabel()
-    let chartSegmentedControl: UISegmentedControl = {
-        let control = UISegmentedControl(items: ["조회", "다운로드"])
-        return control
-      }()
-    
-    lazy var combinedChartView = CombinedChartView()
-    
-    override init(frame: CGRect) {
-        
-        super.init(frame: frame)
-    }
+    let chartSegmentedControl = UISegmentedControl(items: ["조회", "다운로드"])
+    let combinedChartView = CombinedChartView()
     
     override func setHierarchy() {
         addSubviews(underLineView, scrollView)
@@ -55,7 +47,7 @@ final class PhotoDetailView: BaseView {
         contentView.addSubviews(profileContainerView,
                                 heartBtn,
                                 mainPosterImage,
-                                infoContainerView, combinedChartView)
+                                infoContainerView, chartLabel, chartSegmentedControl, combinedChartView)
         
         profileContainerView.addSubviews(profileImageView,
                                          nameLabel,
@@ -67,124 +59,8 @@ final class PhotoDetailView: BaseView {
                                       viewLabel,
                                       viewNumLabel,
                                       downloadLabel,
-                                      downloadNumLabel,
-                                      chartLabel,
-                                      chartSegmentedControl)
+                                      downloadNumLabel)
     }
-    
-//    override func setLayout() {
-//        underLineView.snp.makeConstraints {
-//            $0.top.equalTo(safeAreaLayoutGuide)
-//            $0.horizontalEdges.equalToSuperview()
-//            $0.height.equalTo(0.6)
-//        }
-//        
-//        scrollView.snp.makeConstraints {
-//            $0.width.equalToSuperview()
-//            $0.top.equalTo(underLineView.snp.bottom).offset(2)
-//            $0.bottom.equalToSuperview()
-//        }
-//        
-//        contentView.snp.makeConstraints {
-//            $0.width.equalTo(scrollView.snp.width)
-//            $0.verticalEdges.equalTo(scrollView)
-//        }
-//        
-//        profileContainerView.snp.makeConstraints {
-//            $0.top.equalTo(underLineView.snp.bottom).offset(2)
-//            $0.leading.equalToSuperview().offset(15)
-//            $0.width.greaterThanOrEqualTo(40)
-//            $0.height.equalTo(50)
-//        }
-//        
-//        profileImageView.snp.makeConstraints {
-//            $0.leading.equalToSuperview()
-//            $0.centerY.equalToSuperview()
-//            $0.size.equalTo(35)
-//        }
-//        
-//        creatAtLabel.snp.makeConstraints {
-//            $0.leading.equalTo(profileImageView.snp.trailing).offset(10)
-//            $0.bottom.equalTo(profileImageView.snp.bottom)
-//            $0.trailing.equalToSuperview()
-//        }
-//        
-//        nameLabel.snp.makeConstraints {
-//            $0.leading.equalTo(creatAtLabel.snp.leading)
-//            $0.bottom.equalTo(creatAtLabel.snp.top).offset(-2)
-//            $0.trailing.equalTo(creatAtLabel.snp.trailing)
-//        }
-//        
-//        heartBtn.snp.makeConstraints {
-//            $0.centerY.equalTo(profileImageView.snp.centerY)
-//            $0.trailing.equalToSuperview().offset(-15)
-//            $0.width.equalTo(30)
-//            $0.height.equalTo(28)
-//        }
-//        
-//        mainPosterImage.snp.makeConstraints {
-//            $0.top.equalTo(profileContainerView.snp.bottom)
-//            $0.horizontalEdges.equalToSuperview()
-//        }
-//        
-//        infoContainerView.snp.makeConstraints {
-//            $0.top.equalTo(mainPosterImage.snp.bottom).offset(15)
-//            $0.horizontalEdges.equalToSuperview().inset(15)
-//        }
-//        
-//        infoLabel.snp.makeConstraints {
-//            $0.top.leading.equalToSuperview()
-//        }
-//        
-//        sizeLabel.snp.makeConstraints {
-//            $0.bottom.equalTo(infoLabel.snp.bottom)
-//            $0.leading.equalTo(infoLabel.snp.trailing).offset(100)
-//        }
-//        
-//        sizeNumLabel.snp.makeConstraints {
-//            $0.bottom.equalTo(sizeLabel.snp.bottom)
-//            $0.trailing.equalToSuperview()
-//        }
-//        
-//        viewLabel.snp.makeConstraints {
-//            $0.top.equalTo(sizeLabel.snp.bottom).offset(10)
-//            $0.leading.equalTo(sizeLabel.snp.leading)
-//        }
-//        
-//        viewNumLabel.snp.makeConstraints {
-//            $0.bottom.equalTo(viewLabel.snp.bottom)
-//            $0.trailing.equalToSuperview()
-//        }
-//        
-//        downloadLabel.snp.makeConstraints {
-//            $0.top.equalTo(viewLabel.snp.bottom).offset(10)
-//            $0.leading.equalTo(sizeLabel.snp.leading)
-//        }
-//        
-//        downloadNumLabel.snp.makeConstraints {
-//            $0.bottom.equalTo(downloadLabel.snp.bottom)
-//            $0.trailing.equalToSuperview()
-//        }
-//        
-//        chartLabel.snp.makeConstraints {
-//            $0.top.equalTo(downloadLabel.snp.bottom).offset(50)
-//            $0.leading.equalTo(infoLabel.snp.leading)
-//        }
-//        
-//        chartSegmentedControl.snp.makeConstraints {
-//            $0.leading.equalTo(sizeLabel.snp.leading)
-//            $0.bottom.equalTo(chartLabel.snp.bottom)
-//        }
-//        
-//        combinedChartView.snp.makeConstraints {
-//            $0.top.equalTo(chartSegmentedControl.snp.bottom).offset(10)
-//            $0.leading.equalTo(sizeLabel.snp.leading)
-//            $0.trailing.equalToSuperview().offset(-15)
-//            $0.height.equalTo(300)
-//        }
-//        print(#function, "setLayout 종료")
-//        
-//    }
     
     override func setStyle() {
         underLineView.backgroundColor = .lightGray
@@ -237,7 +113,11 @@ final class PhotoDetailView: BaseView {
     
     func setDataUI(photoDetailModel: PhotoDetailModel) {
         //view.setLayout이 처음 불리는 시점에는 self.view의 width와 height의 크기가 결정되지 않았었음, 왜냐?! vc의 viewDidLoad가 실행되기 이전에 이미 view.setLayout함수는 끝이 나니까
-        
+        DispatchQueue.main.async {
+            print("ScrollView Frame: \(self.scrollView.frame)")
+            print("ScrollView Content Size: \(self.scrollView.contentSize)")
+        }
+        scrollView.alwaysBounceVertical = true
         underLineView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
             $0.horizontalEdges.equalToSuperview()
@@ -245,7 +125,7 @@ final class PhotoDetailView: BaseView {
         }
         
         scrollView.snp.makeConstraints {
-            $0.width.equalToSuperview()
+            $0.horizontalEdges.equalTo(safeAreaLayoutGuide)
             $0.top.equalTo(underLineView.snp.bottom).offset(2)
             $0.bottom.equalToSuperview()
         }
@@ -346,6 +226,7 @@ final class PhotoDetailView: BaseView {
             $0.leading.equalTo(sizeLabel.snp.leading)
             $0.trailing.equalToSuperview().offset(-15)
             $0.height.equalTo(300)
+            $0.bottom.equalToSuperview()
         }
         
         mainPosterImage.setImageKfDownSampling(with: photoDetailModel.selectedImageURL, cornerRadius: 0)
@@ -355,7 +236,6 @@ final class PhotoDetailView: BaseView {
         sizeNumLabel.text = "\(photoDetailModel.selectedImageWidth) x \(photoDetailModel.selectedImageHeight)"
         viewNumLabel.text = photoDetailModel.viewCount.formatted()
         downloadNumLabel.text = photoDetailModel.downloadCount.formatted()
-        
     }
     
 }
@@ -363,14 +243,14 @@ final class PhotoDetailView: BaseView {
 
 
 /*
- 1. line 94에 아래와 같은 코드를 사용하면 왜 레이아웃 에러가 날까
+ 미해결 1.line 94에 아래와 같은 코드를 사용하면 왜 레이아웃 에러가 날까
  profileContainerView.snp.makeConstraints {
      $0.top.equalTo(underLineView.snp.bottom).offset(2)
      $0.leading.equalToSuperview().offset(15)
      $0.trailing.lessThanOrEqualTo(heartBtn.snp.leading).offset(-10)
      $0.height.equalTo(50)
  }
- 2. 아래 레이아웃 에러가 왜 나는지 모르겠다..
+ 해결 / 2. 아래 레이아웃 에러가 왜 나는지 모르겠다..
  (
      "<SnapKit.LayoutConstraint:0x600002606a00@PhotoDetailView.swift#78 UIView:0x101d05320.top == UILayoutGuide:0x600003b089a0.top>",
      "<SnapKit.LayoutConstraint:0x6000026055c0@PhotoDetailView.swift#85 UIScrollView:0x103009e00.top == UIView:0x101d05320.bottom + 2.0>",
@@ -378,7 +258,15 @@ final class PhotoDetailView: BaseView {
      "<NSLayoutConstraint:0x600002131c20 '_UITemporaryLayoutHeight' PhotoProject.PhotoDetailView:0x101d050e0.height == 0   (active)>",
      "<NSLayoutConstraint:0x600002138370 'UIViewSafeAreaLayoutGuide-top' V:|-(0)-[UILayoutGuide:0x600003b089a0'UIViewSafeAreaLayoutGuide']   (active, names: '|':PhotoProject.PhotoDetailView:0x101d050e0 )>"
  )
- 3. view안에 label들로만 채운다면 view snp 설정할 때 height을 주지않아도 알아서 계산으로 들어가는데, 그 view의 bottom을 기준으로 다른 프로퍼티의 top을 잡으니 레이아웃이 원하는대로 되지않는다. 뷰가 그려지는 사이클이 꼬여서 그런거 같은데, 이걸 해결할 수 있는 방법이 있을까
- 4. segmentControl이 왜 안 눌리는가..
- 5. 레이아웃 문제로 스크롤이 안돼서 차트를 확인 못하는 구만..
+ 
+ 해결 / 3. view안에 label들로만 채운다면 view snp 설정할 때 height을 주지않아도 알아서 계산으로 들어가는데, 그 view의 bottom을 기준으로 다른 프로퍼티의 top을 잡으니 레이아웃이 원하는대로 되지않는다. 뷰가 그려지는 사이클이 꼬여서 그런거 같은데, 이걸 해결할 수 있는 방법이 있을까
+ 
+ 해결 / 4. segmentControl이 왜 안 눌리는가..
+ 
+ 미해결 / 5. 레이아웃 문제로 스크롤이 안돼서 차트를 확인 못하는 구만..
+   - 이게 아님. 해결했음에도 스크롤이 안 되는 중..
  */
+
+
+//현재 차트는 구현하였으나, 스크롤이 되지 않고있습니다..
+//차트를 확인하시려면 정말 죄송하지만.. mainPosterImage의 height을 10으로 설정해주시면 차트가 보입니다요..!

--- a/PhotoProject/PhotoProject/Present/PhotoDetail/View/PhotoDetailView.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoDetail/View/PhotoDetailView.swift
@@ -9,6 +9,8 @@ import UIKit
 
 import SnapKit
 import Then
+import Charts
+import DGCharts
 
 final class PhotoDetailView: BaseView {
     
@@ -39,6 +41,8 @@ final class PhotoDetailView: BaseView {
         return control
       }()
     
+    lazy var combinedChartView = CombinedChartView()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
     }
@@ -50,7 +54,7 @@ final class PhotoDetailView: BaseView {
         contentView.addSubviews(profileContainerView,
                                 heartBtn,
                                 mainPosterImage,
-                                infoContainerView)
+                                infoContainerView, combinedChartView)
         
         profileContainerView.addSubviews(profileImageView,
                                          nameLabel,
@@ -174,6 +178,13 @@ final class PhotoDetailView: BaseView {
             $0.bottom.equalTo(chartLabel.snp.bottom)
         }
         
+        combinedChartView.snp.makeConstraints {
+            $0.top.equalTo(chartSegmentedControl.snp.bottom).offset(10)
+            $0.leading.equalTo(sizeLabel.snp.leading)
+            $0.trailing.equalToSuperview().offset(-15)
+            $0.height.equalTo(300)
+        }
+        
     }
     
     override func setStyle() {
@@ -219,6 +230,10 @@ final class PhotoDetailView: BaseView {
             $0.isEnabled = true
             $0.isUserInteractionEnabled = true
         }
+        
+        combinedChartView.do {
+            $0.backgroundColor = .blue
+        }
     }
     
     func setDataUI(photoDetailModel: PhotoDetailModel) {
@@ -254,4 +269,5 @@ final class PhotoDetailView: BaseView {
  )
  3. view안에 label들로만 채운다면 view snp 설정할 때 height을 주지않아도 알아서 계산으로 들어가는데, 그 view의 bottom을 기준으로 다른 프로퍼티의 top을 잡으니 레이아웃이 원하는대로 되지않는다. 뷰가 그려지는 사이클이 꼬여서 그런거 같은데, 이걸 해결할 수 있는 방법이 있을까
  4. segmentControl이 왜 안 눌리는가..
+ 5. 레이아웃 문제로 스크롤이 안돼서 차트를 확인 못하는 구만..
  */

--- a/PhotoProject/PhotoProject/Present/PhotoSearch/PhotoSearchViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoSearch/PhotoSearchViewController.swift
@@ -260,6 +260,14 @@ extension PhotoSearchViewController: UICollectionViewDelegate, UICollectionViewD
                 let selectedImageHeight = item.height
                 let downloadCount = result.downloads.historical.change
                 let viewCount = result.views.historical.change
+                var day30ViewCount: [Int] = []
+                for i in result.views.historical.values {
+                    day30ViewCount.append(i.value)
+                }
+                var day30DownCount: [Int] = []
+                for i in result.downloads.historical.values {
+                    day30DownCount.append(i.value)
+                }
                 
                 let vc = PhotoDetailViewController()
                 vc.photoDetailModel = PhotoDetailModel(profileImageURL: profileImageURL,
@@ -269,7 +277,8 @@ extension PhotoSearchViewController: UICollectionViewDelegate, UICollectionViewD
                                                        selectedImageWidth: selectedImageWidth,
                                                        selectedImageHeight: selectedImageHeight,
                                                        downloadCount: downloadCount,
-                                                       viewCount: viewCount)
+                                                       viewCount: viewCount, day30ViewCount: day30ViewCount,
+                                                       day30DownCount: day30DownCount)
                 
                 self.navigationController?.pushViewController(vc, animated: true)
             default:

--- a/PhotoProject/PhotoProject/Present/PhotoSearch/PhotoSearchViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoSearch/PhotoSearchViewController.swift
@@ -268,6 +268,28 @@ extension PhotoSearchViewController: UICollectionViewDelegate, UICollectionViewD
                 for i in result.downloads.historical.values {
                     day30DownCount.append(i.value)
                 }
+                var view30Days = [String]()
+                for i in result.views.historical.values {
+                    print(i.date)
+                    view30Days.append(DateFormatterManager.shard.setDateString(strDate: i.date, format: "MM.dd"))
+                }
+                var view30DaysValue = [Int]()
+                for i in result.views.historical.values {
+                    view30DaysValue.append(i.value)
+                }
+                
+                var download30Days = [String]()
+                for i in result.downloads.historical.values {
+                    print(i.date)
+                    download30Days.append(DateFormatterManager.shard.setDateString(strDate: i.date, format: "MM.dd"))
+                }
+                var download30DaysValue = [Int]()
+                for i in result.downloads.historical.values {
+                    download30DaysValue.append(i.value)
+                }
+                
+                let monthView = MonthView(monthViewDates: view30Days, monthViewValues: view30DaysValue)
+                let monthDownload = MonthDownload(monthDownloadDates: download30Days, monthDownloadValues: download30DaysValue)
                 
                 let vc = PhotoDetailViewController()
                 vc.photoDetailModel = PhotoDetailModel(profileImageURL: profileImageURL,
@@ -277,8 +299,10 @@ extension PhotoSearchViewController: UICollectionViewDelegate, UICollectionViewD
                                                        selectedImageWidth: selectedImageWidth,
                                                        selectedImageHeight: selectedImageHeight,
                                                        downloadCount: downloadCount,
-                                                       viewCount: viewCount, day30ViewCount: day30ViewCount,
-                                                       day30DownCount: day30DownCount)
+                                                       viewCount: viewCount, monthViewTotalCount: day30ViewCount,
+                                                       monthDownloadTotalCount: day30ViewCount,
+                                                       monthView: monthView,
+                                                       monthDownload: monthDownload)
                 
                 self.navigationController?.pushViewController(vc, animated: true)
             default:

--- a/PhotoProject/PhotoProject/Present/PhotoSearch/PhotoSearchViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoSearch/PhotoSearchViewController.swift
@@ -236,7 +236,7 @@ extension PhotoSearchViewController: UICollectionViewDelegate, UICollectionViewD
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchResultCollectionViewCell.cellIdentifier, for: indexPath) as! SearchResultCollectionViewCell
         let row = searchList[indexPath.item]
         
-        cell.configureCell(image: row.urls.raw, likes: row.likes)
+        cell.configureCell(image: row.urls.thumb, likes: row.likes)
         
         return cell
     }

--- a/PhotoProject/PhotoProject/Present/PhotoSearch/PhotoSearchViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoSearch/PhotoSearchViewController.swift
@@ -255,7 +255,7 @@ extension PhotoSearchViewController: UICollectionViewDelegate, UICollectionViewD
                 let profileImageURL = item.user.profile_image.medium
                 let profileName = item.user.name
                 let createAt = item.created_at
-                let selectedImageURL = item.urls.raw
+                let selectedImageURL = item.urls.regular
                 let selectedImageWidth = item.width
                 let selectedImageHeight = item.height
                 let downloadCount = result.downloads.historical.change

--- a/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
@@ -149,6 +149,14 @@ extension PhotoTopicViewController: UICollectionViewDelegate, UICollectionViewDa
                 let selectedImageHeight = item.height
                 let downloadCount = result.downloads.historical.change
                 let viewCount = result.views.historical.change
+                var day30ViewCount: [Int] = []
+                for i in result.views.historical.values {
+                    day30ViewCount.append(i.value)
+                }
+                var day30DownCount: [Int] = []
+                for i in result.downloads.historical.values {
+                    day30DownCount.append(i.value)
+                }
                 
                 let vc = PhotoDetailViewController()
                 vc.photoDetailModel = PhotoDetailModel(profileImageURL: profileImageURL,
@@ -158,7 +166,8 @@ extension PhotoTopicViewController: UICollectionViewDelegate, UICollectionViewDa
                                                        selectedImageWidth: selectedImageWidth,
                                                        selectedImageHeight: selectedImageHeight,
                                                        downloadCount: downloadCount,
-                                                       viewCount: viewCount)
+                                                       viewCount: viewCount, day30ViewCount: day30ViewCount,
+                                                       day30DownCount: day30ViewCount)
                 
                 self.navigationController?.pushViewController(vc, animated: true)
             default:

--- a/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
@@ -140,7 +140,6 @@ extension PhotoTopicViewController: UICollectionViewDelegate, UICollectionViewDa
             statusCode in
             switch statusCode {
             case (200..<299):
-                print("result : \n", result)
                 let profileImageURL = item.user.profile_image.medium
                 let profileName = item.user.name
                 let createAt = item.createdAt
@@ -157,6 +156,28 @@ extension PhotoTopicViewController: UICollectionViewDelegate, UICollectionViewDa
                 for i in result.downloads.historical.values {
                     day30DownCount.append(i.value)
                 }
+                var view30Days = [String]()
+                for i in result.views.historical.values {
+                    print(i.date)
+                    view30Days.append(DateFormatterManager.shard.setDateString(strDate: i.date, format: "MM.dd"))
+                }
+                var view30DaysValue = [Int]()
+                for i in result.views.historical.values {
+                    view30DaysValue.append(i.value)
+                }
+                
+                var download30Days = [String]()
+                for i in result.downloads.historical.values {
+                    print(i.date)
+                    download30Days.append(DateFormatterManager.shard.setDateString(strDate: i.date, format: "MM.dd"))
+                }
+                var download30DaysValue = [Int]()
+                for i in result.downloads.historical.values {
+                    download30DaysValue.append(i.value)
+                }
+                
+                let monthView = MonthView(monthViewDates: view30Days, monthViewValues: view30DaysValue)
+                let monthDownload = MonthDownload(monthDownloadDates: download30Days, monthDownloadValues: download30DaysValue)
                 
                 let vc = PhotoDetailViewController()
                 vc.photoDetailModel = PhotoDetailModel(profileImageURL: profileImageURL,
@@ -166,8 +187,10 @@ extension PhotoTopicViewController: UICollectionViewDelegate, UICollectionViewDa
                                                        selectedImageWidth: selectedImageWidth,
                                                        selectedImageHeight: selectedImageHeight,
                                                        downloadCount: downloadCount,
-                                                       viewCount: viewCount, day30ViewCount: day30ViewCount,
-                                                       day30DownCount: day30ViewCount)
+                                                       viewCount: viewCount, monthViewTotalCount: day30ViewCount,
+                                                       monthDownloadTotalCount: day30ViewCount,
+                                                       monthView: monthView,
+                                                       monthDownload: monthDownload)
                 
                 self.navigationController?.pushViewController(vc, animated: true)
             default:

--- a/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
@@ -144,7 +144,7 @@ extension PhotoTopicViewController: UICollectionViewDelegate, UICollectionViewDa
                 let profileImageURL = item.user.profile_image.medium
                 let profileName = item.user.name
                 let createAt = item.createdAt
-                let selectedImageURL = item.urls.raw
+                let selectedImageURL = item.urls.regular
                 let selectedImageWidth = item.width
                 let selectedImageHeight = item.height
                 let downloadCount = result.downloads.historical.change

--- a/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
@@ -202,7 +202,7 @@ extension PhotoTopicViewController: UICollectionViewDelegate, UICollectionViewDa
         
         let item = horizontalSections[indexPath.section][indexPath.item]
         
-        cell.configureCellInTopic(image: item.urls.raw, likes: item.likes)
+        cell.configureCellInTopic(image: item.urls.thumb, likes: item.likes)
         
         return cell
     }

--- a/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
@@ -82,7 +82,15 @@ private extension PhotoTopicViewController {
                     for j in result {
                         self.horizontalSections[i].append(j)
                     }
-                    self.mainView.topicCollectionView.refreshControl?.endRefreshing()
+                    DispatchQueue.main.async {
+                        if (isRefreshControl ?? false) {
+                            for i in 0..<self.horizontalSections.count {
+                                self.mainView.topicCollectionView.scrollToItem(at: IndexPath(item: 0, section: i), at: .left, animated: true)
+                            }
+                        }
+                        self.mainView.topicCollectionView.refreshControl?.endRefreshing()
+                    }
+                    
                 default:
                     return print("getPhotoSearch Error")
                 }
@@ -148,6 +156,7 @@ extension PhotoTopicViewController: UICollectionViewDelegate, UICollectionViewDa
                 let selectedImageHeight = item.height
                 let downloadCount = result.downloads.historical.change
                 let viewCount = result.views.historical.change
+                
                 var day30ViewCount: [Int] = []
                 for i in result.views.historical.values {
                     day30ViewCount.append(i.value)


### PR DESCRIPTION
## Related Issues 💭
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #12 

## What is the PR? 🔍
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
- PhotoDetail 차트 구현과 xcconfig를 적용합니다.



## Changes 📝
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
- [x] client-id 재발급 및 xcconfig 적용
- [x] PhotoSearch, PhotoTopic 뷰 - image thumb 값으로 변경
- [x] PhotoTopic 뷰 - 새로고침 시 각 섹션 index 0으로 돌아오기
- PhotoDetail 뷰
  - [x] combinedChart 구현
  - [x] posterImage 크기 동적 처리
  - [x] 레이아웃 에러 수정
  - [x] poster image regular로 변경

## Screenshot 📷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
- photodetail view의 scroll가 작동하지 않아 mainPoster의 크기를 10으로 설정하였습니다.

|    기능    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/cb4879b4-04b8-4e4a-a865-4fd2d87e3166" width ="180">|

## To Do 🙏
<!-- 보완해야할 것. -->
- PhotoDetail Scroll..
