### PR TITLE
[Feat] 22회차 DailyTask 25.01.23 (#19)

### DIFF
--- a/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
+++ b/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		9EEB88CB2D4236EC00E0C6C4 /* NicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88C52D4236EC00E0C6C4 /* NicknameViewController.swift */; };
 		9EEB88CC2D4236EC00E0C6C4 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88C62D4236EC00E0C6C4 /* OnboardingViewController.swift */; };
 		9EEB88CD2D4236EC00E0C6C4 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88C72D4236EC00E0C6C4 /* ProfileViewController.swift */; };
+		9EEB88D02D4237DA00E0C6C4 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88CF2D4237DA00E0C6C4 /* UserDefaultsManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -101,6 +102,7 @@
 		9EEB88C52D4236EC00E0C6C4 /* NicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameViewController.swift; sourceTree = "<group>"; };
 		9EEB88C62D4236EC00E0C6C4 /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
 		9EEB88C72D4236EC00E0C6C4 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
+		9EEB88CF2D4237DA00E0C6C4 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -248,6 +250,7 @@
 				9ED691072D3BFEA8007E76E8 /* Enums */,
 				9E57015E2D3BBF9200D62846 /* DateFormatterManager.swift */,
 				9E57015F2D3BBF9200D62846 /* UIAlertManager.swift */,
+				9EEB88CF2D4237DA00E0C6C4 /* UserDefaultsManager.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -469,6 +472,7 @@
 				9EEB88892D41BD0800E0C6C4 /* ViewTransitionType.swift in Sources */,
 				9ED691092D3BFEEE007E76E8 /* SearchResultStateType.swift in Sources */,
 				9ED691312D3D59E4007E76E8 /* TopicIDType.swift in Sources */,
+				9EEB88D02D4237DA00E0C6C4 /* UserDefaultsManager.swift in Sources */,
 				9E57016A2D3BC56700D62846 /* Bundle+Extension.swift in Sources */,
 				9EEB88C92D4236EC00E0C6C4 /* BirthdayViewController.swift in Sources */,
 				9EEB88CA2D4236EC00E0C6C4 /* LevelViewController.swift in Sources */,

--- a/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
+++ b/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
@@ -49,6 +49,11 @@
 		9ED691A72D3FE8AE007E76E8 /* UnsplahTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED691A62D3FE8AE007E76E8 /* UnsplahTargetType.swift */; };
 		9EEB88872D40E64B00E0C6C4 /* NetworkResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88862D40E64B00E0C6C4 /* NetworkResultType.swift */; };
 		9EEB88892D41BD0800E0C6C4 /* ViewTransitionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88882D41BD0800E0C6C4 /* ViewTransitionType.swift */; };
+		9EEB88C92D4236EC00E0C6C4 /* BirthdayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88C32D4236EC00E0C6C4 /* BirthdayViewController.swift */; };
+		9EEB88CA2D4236EC00E0C6C4 /* LevelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88C42D4236EC00E0C6C4 /* LevelViewController.swift */; };
+		9EEB88CB2D4236EC00E0C6C4 /* NicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88C52D4236EC00E0C6C4 /* NicknameViewController.swift */; };
+		9EEB88CC2D4236EC00E0C6C4 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88C62D4236EC00E0C6C4 /* OnboardingViewController.swift */; };
+		9EEB88CD2D4236EC00E0C6C4 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88C72D4236EC00E0C6C4 /* ProfileViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -91,6 +96,11 @@
 		9ED691A62D3FE8AE007E76E8 /* UnsplahTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsplahTargetType.swift; sourceTree = "<group>"; };
 		9EEB88862D40E64B00E0C6C4 /* NetworkResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResultType.swift; sourceTree = "<group>"; };
 		9EEB88882D41BD0800E0C6C4 /* ViewTransitionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewTransitionType.swift; sourceTree = "<group>"; };
+		9EEB88C32D4236EC00E0C6C4 /* BirthdayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthdayViewController.swift; sourceTree = "<group>"; };
+		9EEB88C42D4236EC00E0C6C4 /* LevelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelViewController.swift; sourceTree = "<group>"; };
+		9EEB88C52D4236EC00E0C6C4 /* NicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameViewController.swift; sourceTree = "<group>"; };
+		9EEB88C62D4236EC00E0C6C4 /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
+		9EEB88C72D4236EC00E0C6C4 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -182,10 +192,12 @@
 		9E5701282D3BBB3E00D62846 /* Present */ = {
 			isa = PBXGroup;
 			children = (
+				9EEB88CE2D42372F00E0C6C4 /* Onboarding */,
 				9ED690F82D3BC7E9007E76E8 /* TabBar */,
+				9EEB88C82D4236EC00E0C6C4 /* Profile */,
+				9E57012B2D3BBB6300D62846 /* PhotoTopic */,
 				9E5701292D3BBB4800D62846 /* PhotoSearch */,
 				9E57012A2D3BBB5400D62846 /* PhotoDetail */,
-				9E57012B2D3BBB6300D62846 /* PhotoTopic */,
 			);
 			path = Present;
 			sourceTree = "<group>";
@@ -346,6 +358,25 @@
 			path = PhotoTopic;
 			sourceTree = "<group>";
 		};
+		9EEB88C82D4236EC00E0C6C4 /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				9EEB88C32D4236EC00E0C6C4 /* BirthdayViewController.swift */,
+				9EEB88C42D4236EC00E0C6C4 /* LevelViewController.swift */,
+				9EEB88C52D4236EC00E0C6C4 /* NicknameViewController.swift */,
+				9EEB88C72D4236EC00E0C6C4 /* ProfileViewController.swift */,
+			);
+			path = Profile;
+			sourceTree = "<group>";
+		};
+		9EEB88CE2D42372F00E0C6C4 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				9EEB88C62D4236EC00E0C6C4 /* OnboardingViewController.swift */,
+			);
+			path = Onboarding;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -439,6 +470,11 @@
 				9ED691092D3BFEEE007E76E8 /* SearchResultStateType.swift in Sources */,
 				9ED691312D3D59E4007E76E8 /* TopicIDType.swift in Sources */,
 				9E57016A2D3BC56700D62846 /* Bundle+Extension.swift in Sources */,
+				9EEB88C92D4236EC00E0C6C4 /* BirthdayViewController.swift in Sources */,
+				9EEB88CA2D4236EC00E0C6C4 /* LevelViewController.swift in Sources */,
+				9EEB88CB2D4236EC00E0C6C4 /* NicknameViewController.swift in Sources */,
+				9EEB88CC2D4236EC00E0C6C4 /* OnboardingViewController.swift in Sources */,
+				9EEB88CD2D4236EC00E0C6C4 /* ProfileViewController.swift in Sources */,
 				9E57016B2D3BC56700D62846 /* UILabel+Extension.swift in Sources */,
 				9ED691A72D3FE8AE007E76E8 /* UnsplahTargetType.swift in Sources */,
 				9E57016C2D3BC56700D62846 /* UITextField+Extension.swift in Sources */,

--- a/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
+++ b/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		9EEB88CC2D4236EC00E0C6C4 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88C62D4236EC00E0C6C4 /* OnboardingViewController.swift */; };
 		9EEB88CD2D4236EC00E0C6C4 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88C72D4236EC00E0C6C4 /* ProfileViewController.swift */; };
 		9EEB88D02D4237DA00E0C6C4 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88CF2D4237DA00E0C6C4 /* UserDefaultsManager.swift */; };
+		9EEB88D32D4252ED00E0C6C4 /* LevelDelegateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEB88D22D4252ED00E0C6C4 /* LevelDelegateProtocol.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -103,6 +104,7 @@
 		9EEB88C62D4236EC00E0C6C4 /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
 		9EEB88C72D4236EC00E0C6C4 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		9EEB88CF2D4237DA00E0C6C4 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
+		9EEB88D22D4252ED00E0C6C4 /* LevelDelegateProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelDelegateProtocol.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -247,6 +249,7 @@
 		9E57015D2D3BBF8B00D62846 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				9EEB88D12D4252CE00E0C6C4 /* Protocol */,
 				9ED691072D3BFEA8007E76E8 /* Enums */,
 				9E57015E2D3BBF9200D62846 /* DateFormatterManager.swift */,
 				9E57015F2D3BBF9200D62846 /* UIAlertManager.swift */,
@@ -380,6 +383,14 @@
 			path = Onboarding;
 			sourceTree = "<group>";
 		};
+		9EEB88D12D4252CE00E0C6C4 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				9EEB88D22D4252ED00E0C6C4 /* LevelDelegateProtocol.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -486,6 +497,7 @@
 				9ED691252D3D37F7007E76E8 /* PhotoTopicView.swift in Sources */,
 				9E5701222D3BBAF800D62846 /* SceneDelegate.swift in Sources */,
 				9ED690FE2D3BC87B007E76E8 /* PhotoDetailViewController.swift in Sources */,
+				9EEB88D32D4252ED00E0C6C4 /* LevelDelegateProtocol.swift in Sources */,
 				9ED6912A2D3D3BF8007E76E8 /* PhotoTopicCollectionHeaderView.swift in Sources */,
 				9ED691222D3D2484007E76E8 /* PhotoDetailModel.swift in Sources */,
 				9ED690FC2D3BC870007E76E8 /* PhotoSearchViewController.swift in Sources */,

--- a/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
+++ b/PhotoProject/PhotoProject.xcodeproj/project.pbxproj
@@ -364,8 +364,8 @@
 		9EEB88C82D4236EC00E0C6C4 /* Profile */ = {
 			isa = PBXGroup;
 			children = (
-				9EEB88C32D4236EC00E0C6C4 /* BirthdayViewController.swift */,
 				9EEB88C42D4236EC00E0C6C4 /* LevelViewController.swift */,
+				9EEB88C32D4236EC00E0C6C4 /* BirthdayViewController.swift */,
 				9EEB88C52D4236EC00E0C6C4 /* NicknameViewController.swift */,
 				9EEB88C72D4236EC00E0C6C4 /* ProfileViewController.swift */,
 			);

--- a/PhotoProject/PhotoProject/Application/SceneDelegate.swift
+++ b/PhotoProject/PhotoProject/Application/SceneDelegate.swift
@@ -12,11 +12,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow.init(windowScene: scene)
         
-        window?.rootViewController = TabBarController()
+        let isNotFirstLoading = UserDefaultsManager.shared.isNotFirstLoading
+        print("isNotFirstLoading : \(isNotFirstLoading)")
+        switch isNotFirstLoading {
+        case true:
+            window?.rootViewController = TabBarController()
+        case false:
+            window?.rootViewController = OnboardingViewController()
+        }
         window?.makeKeyAndVisible()
     }
 

--- a/PhotoProject/PhotoProject/Global/Base/BaseView.swift
+++ b/PhotoProject/PhotoProject/Global/Base/BaseView.swift
@@ -21,7 +21,9 @@ class BaseView: UIView {
     
     func setLayout() {}
     
-    func setStyle() {}
+    func setStyle() {
+        self.backgroundColor = .white
+    }
     
     @available(*, unavailable)
     required init?(coder: NSCoder) {

--- a/PhotoProject/PhotoProject/Global/Utils/DateFormatterManager.swift
+++ b/PhotoProject/PhotoProject/Global/Utils/DateFormatterManager.swift
@@ -37,6 +37,13 @@ final class DateFormatterManager {
         return outputDate.string(from: date)
     }
     
+    func setDateStringFromString(date: String, format: String) -> Date {
+        let outputDate = DateFormatter()
+        outputDate.dateFormat = format
+        
+        return outputDate.date(from: date) ?? Date()
+    }
+    
     func setDateInChat(strDate: String) -> String {
         let inputDate = DateFormatter()
         //strDate 형식에 맞는 포맷 설정

--- a/PhotoProject/PhotoProject/Global/Utils/DateFormatterManager.swift
+++ b/PhotoProject/PhotoProject/Global/Utils/DateFormatterManager.swift
@@ -30,6 +30,13 @@ final class DateFormatterManager {
         return outputDate.string(from: date)
     }
     
+    func setDateStringFromDate(date: Date, format: String) -> String {
+        let outputDate = DateFormatter()
+        outputDate.dateFormat = format
+        
+        return outputDate.string(from: date)
+    }
+    
     func setDateInChat(strDate: String) -> String {
         let inputDate = DateFormatter()
         //strDate 형식에 맞는 포맷 설정

--- a/PhotoProject/PhotoProject/Global/Utils/Protocol/LevelDelegateProtocol.swift
+++ b/PhotoProject/PhotoProject/Global/Utils/Protocol/LevelDelegateProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  LevelDelegateProtocol.swift
+//  PhotoProject
+//
+//  Created by 박신영 on 1/23/25.
+//
+
+import Foundation
+
+protocol LevelDelegateProtocol {
+    
+    func setLevelData(levelTitle: String)
+    
+}

--- a/PhotoProject/PhotoProject/Global/Utils/UserDefaultsManager.swift
+++ b/PhotoProject/PhotoProject/Global/Utils/UserDefaultsManager.swift
@@ -1,0 +1,25 @@
+//
+//  UserDefaultsManager.swift
+//  PhotoProject
+//
+//  Created by 박신영 on 1/23/25.
+//
+
+import Foundation
+
+final class UserDefaultsManager {
+    
+    static let shared = UserDefaultsManager()
+    
+    private init() {}
+    
+    var isNotFirstLoading: Bool {
+        get {
+            return UserDefaults.standard.bool(forKey: "isNotFirstLoading")
+        }
+        set {
+            return UserDefaults.standard.set(newValue, forKey: "isNotFirstLoading")
+        }
+    }
+    
+}

--- a/PhotoProject/PhotoProject/Global/Utils/UserDefaultsManager.swift
+++ b/PhotoProject/PhotoProject/Global/Utils/UserDefaultsManager.swift
@@ -31,4 +31,13 @@ final class UserDefaultsManager {
         }
     }
     
+    var birthday: String {
+        get {
+            return UserDefaults.standard.string(forKey: "birthday") ?? "Unknown"
+        }
+        set {
+            return UserDefaults.standard.set(newValue, forKey: "birthday")
+        }
+    }
+    
 }

--- a/PhotoProject/PhotoProject/Global/Utils/UserDefaultsManager.swift
+++ b/PhotoProject/PhotoProject/Global/Utils/UserDefaultsManager.swift
@@ -24,7 +24,7 @@ final class UserDefaultsManager {
     
     var nickname: String {
         get {
-            return UserDefaults.standard.string(forKey: "nickname") ?? "Unknown"
+            return UserDefaults.standard.string(forKey: "nickname") ?? "NO NAME"
         }
         set {
             return UserDefaults.standard.set(newValue, forKey: "nickname")
@@ -33,11 +33,21 @@ final class UserDefaultsManager {
     
     var birthday: String {
         get {
-            return UserDefaults.standard.string(forKey: "birthday") ?? "Unknown"
+            return UserDefaults.standard.string(forKey: "birthday") ?? "NO DATE"
         }
         set {
             return UserDefaults.standard.set(newValue, forKey: "birthday")
         }
     }
     
+    var level: String {
+        get {
+            return UserDefaults.standard.string(forKey: "level") ?? "NO LEVEL"
+        }
+        set {
+            return UserDefaults.standard.set(newValue, forKey: "level")
+        }
+    }
+    
 }
+//bool, int는 기본 값이 있다.

--- a/PhotoProject/PhotoProject/Global/Utils/UserDefaultsManager.swift
+++ b/PhotoProject/PhotoProject/Global/Utils/UserDefaultsManager.swift
@@ -22,4 +22,13 @@ final class UserDefaultsManager {
         }
     }
     
+    var nickname: String {
+        get {
+            return UserDefaults.standard.string(forKey: "nickname") ?? "Unknown"
+        }
+        set {
+            return UserDefaults.standard.set(newValue, forKey: "nickname")
+        }
+    }
+    
 }

--- a/PhotoProject/PhotoProject/Present/Onboarding/OnboardingViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Onboarding/OnboardingViewController.swift
@@ -6,25 +6,61 @@
 //
 
 import UIKit
-import SnapKit
 
-class OnboardingViewController: UIViewController {
+import SnapKit
+import Then
+
+final class OnboardingViewController: UIViewController {
 
     let button = UIButton()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .darkGray
+        
+        setHierarchy()
+        setLayout()
+        setStyle()
+    }
+ 
+}
+
+private extension OnboardingViewController {
+    
+    func setHierarchy() {
         view.addSubview(button)
-        button.snp.makeConstraints { make in
-            make.bottom.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(24)
-            make.height.equalTo(50)
-        }
-        button.layer.cornerRadius = 25
-        button.backgroundColor = .white
-        button.setTitleColor(.darkGray, for: .normal)
-        button.setTitle("시작하기", for: .normal)
     }
     
- 
+    func setLayout() {
+        button.snp.makeConstraints {
+            $0.bottom.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(24)
+            $0.height.equalTo(50)
+        }
+    }
+    
+    func setStyle() {
+        view.backgroundColor = .darkGray
+        
+        button.do {
+            $0.layer.cornerRadius = 25
+            $0.backgroundColor = .white
+            $0.setTitleColor(.darkGray, for: .normal)
+            $0.setTitle("시작하기", for: .normal)
+            $0.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        }
+    }
+    
+    @objc
+    func buttonTapped() {
+        UserDefaultsManager.shared.isNotFirstLoading = true
+        print("UserDefaultsManager.shared.isNotFirstLoading: \(UserDefaultsManager.shared.isNotFirstLoading)")
+        
+        //rootVC 탭바VC로 변경
+        guard let windowScene =  UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = windowScene.windows.first
+        else { return }
+
+        window.rootViewController = UINavigationController(rootViewController: TabBarController())
+        window.makeKeyAndVisible()
+    }
+    
 }

--- a/PhotoProject/PhotoProject/Present/Onboarding/OnboardingViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Onboarding/OnboardingViewController.swift
@@ -1,0 +1,30 @@
+//
+//  OnboardingViewController.swift
+//  PhotoProject
+//
+//  Created by 박신영 on 1/23/25.
+//
+
+import UIKit
+import SnapKit
+
+class OnboardingViewController: UIViewController {
+
+    let button = UIButton()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .darkGray
+        view.addSubview(button)
+        button.snp.makeConstraints { make in
+            make.bottom.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(24)
+            make.height.equalTo(50)
+        }
+        button.layer.cornerRadius = 25
+        button.backgroundColor = .white
+        button.setTitleColor(.darkGray, for: .normal)
+        button.setTitle("시작하기", for: .normal)
+    }
+    
+ 
+}

--- a/PhotoProject/PhotoProject/Present/PhotoDetail/PhotoDetailViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoDetail/PhotoDetailViewController.swift
@@ -18,7 +18,6 @@ final class PhotoDetailViewController: BaseViewController {
     override func loadView() {
         print(#function)
         view = mainView
-        setChildrenViewLayout(view: mainView)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -27,6 +26,7 @@ final class PhotoDetailViewController: BaseViewController {
         guard let photoDetailModel else {return}
         DispatchQueue.main.async {
             self.mainView.setDataUI(photoDetailModel: photoDetailModel)
+            self.setChildrenViewLayout(view: self.mainView)
             self.setChart(title: "한달 조회 수", dataPoints: photoDetailModel.monthView.monthViewDates, lineValues: photoDetailModel.monthView.monthViewValues)
         }
     }

--- a/PhotoProject/PhotoProject/Present/PhotoDetail/View/PhotoDetailView.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoDetail/View/PhotoDetailView.swift
@@ -66,6 +66,11 @@ final class PhotoDetailView: BaseView {
                                          creatAtLabel)
     }
     
+    //layoutIfNeeded 더 연구.
+//    override func layoutIfNeeded() {
+//        <#code#>
+//    }
+    
     override func setLayout() {
         //view.setLayout이 처음 불리는 시점에는 self.view의 width와 height의 크기가 결정되지 않았었음,
         //  왜냐?! vc의 viewDidLoad가 실행되기 이전에 이미 view.setLayout함수는 끝이 나니까

--- a/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
@@ -179,6 +179,7 @@ private extension PhotoTopicViewController {
     @objc
     func navRightBtnTapped() {
         print(#function)
+        viewTransition(viewController: ProfileViewController(), transitionStyle: .push)
     }
     
     @objc

--- a/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
@@ -180,7 +180,8 @@ private extension PhotoTopicViewController {
     func navRightBtnTapped() {
         print(#function)
         let vc = ProfileViewController(nickname: UserDefaultsManager.shared.nickname,
-                                       birthday: UserDefaultsManager.shared.birthday)
+                                       birthday: UserDefaultsManager.shared.birthday,
+                                       level: UserDefaultsManager.shared.level)
         
         viewTransition(viewController: vc, transitionStyle: .push)
     }

--- a/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
+++ b/PhotoProject/PhotoProject/Present/PhotoTopic/PhotoTopicViewController.swift
@@ -179,7 +179,10 @@ private extension PhotoTopicViewController {
     @objc
     func navRightBtnTapped() {
         print(#function)
-        viewTransition(viewController: ProfileViewController(), transitionStyle: .push)
+        let vc = ProfileViewController(nickname: UserDefaultsManager.shared.nickname,
+                                       birthday: UserDefaultsManager.shared.birthday)
+        
+        viewTransition(viewController: vc, transitionStyle: .push)
     }
     
     @objc

--- a/PhotoProject/PhotoProject/Present/Profile/BirthdayViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/BirthdayViewController.swift
@@ -7,30 +7,51 @@
 
 
 import UIKit
+
 import SnapKit
 
-class BirthdayViewController: UIViewController {
+final class BirthdayViewController: BaseViewController {
 
-    let datePicker = UIDatePicker()
+    private let datePicker = UIDatePicker()
+    var onChange: ((String) -> Void)?
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureView()
+        
     }
     
-    @objc func okButtonTapped() {
-        print(#function)
-    }
-    
-    func configureView() {
-        navigationItem.title = "생일"
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인", style: .plain, target: self, action: #selector(okButtonTapped))
-        view.backgroundColor = .white
+    override func setHierarchy() {
         view.addSubview(datePicker)
-        datePicker.snp.makeConstraints { make in
-            make.centerX.top.equalTo(view.safeAreaLayoutGuide)
+    }
+    
+    override func setLayout() {
+        datePicker.snp.makeConstraints {
+            $0.centerX.top.equalTo(view.safeAreaLayoutGuide)
         }
+    }
+    
+    override func setStyle() {
+        navigationItem.title = "생일"
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인",
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(okButtonTapped))
+        view.backgroundColor = .white
+        
         datePicker.preferredDatePickerStyle = .wheels
         datePicker.datePickerMode = .date
     }
+    
+    @objc
+    private func okButtonTapped() {
+        print(#function)
+        
+        let birthday = DateFormatterManager.shard.setDateStringFromDate(date: datePicker.date, format: "yyyy-MM-dd")
+        UserDefaultsManager.shared.birthday = birthday
+        
+        onChange?(birthday)
+        
+        navigationController?.popViewController(animated: true)
+    }
+    
 }

--- a/PhotoProject/PhotoProject/Present/Profile/BirthdayViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/BirthdayViewController.swift
@@ -1,0 +1,36 @@
+//
+//  BirthdayViewController.swift
+//  PhotoProject
+//
+//  Created by 박신영 on 1/23/25.
+//
+
+
+import UIKit
+import SnapKit
+
+class BirthdayViewController: UIViewController {
+
+    let datePicker = UIDatePicker()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureView()
+    }
+    
+    @objc func okButtonTapped() {
+        print(#function)
+    }
+    
+    func configureView() {
+        navigationItem.title = "생일"
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인", style: .plain, target: self, action: #selector(okButtonTapped))
+        view.backgroundColor = .white
+        view.addSubview(datePicker)
+        datePicker.snp.makeConstraints { make in
+            make.centerX.top.equalTo(view.safeAreaLayoutGuide)
+        }
+        datePicker.preferredDatePickerStyle = .wheels
+        datePicker.datePickerMode = .date
+    }
+}

--- a/PhotoProject/PhotoProject/Present/Profile/BirthdayViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/BirthdayViewController.swift
@@ -36,10 +36,19 @@ final class BirthdayViewController: BaseViewController {
                                                             style: .plain,
                                                             target: self,
                                                             action: #selector(okButtonTapped))
+        
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "chevron.left"),
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(okButtonTapped))
         view.backgroundColor = .white
         
         datePicker.preferredDatePickerStyle = .wheels
         datePicker.datePickerMode = .date
+        
+        let birthday = DateFormatterManager.shard.setDateStringFromString(date: UserDefaultsManager.shared.birthday, format: "yyyy-MM-dd")
+        
+        datePicker.setDate(birthday, animated: true)
     }
     
     @objc

--- a/PhotoProject/PhotoProject/Present/Profile/BirthdayViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/BirthdayViewController.swift
@@ -12,13 +12,9 @@ import SnapKit
 
 final class BirthdayViewController: BaseViewController {
 
-    private let datePicker = UIDatePicker()
     var onChange: ((String) -> Void)?
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-    }
+    private let datePicker = UIDatePicker()
     
     override func setHierarchy() {
         view.addSubview(datePicker)
@@ -43,12 +39,13 @@ final class BirthdayViewController: BaseViewController {
                                                             action: #selector(okButtonTapped))
         view.backgroundColor = .white
         
-        datePicker.preferredDatePickerStyle = .wheels
-        datePicker.datePickerMode = .date
-        
         let birthday = DateFormatterManager.shard.setDateStringFromString(date: UserDefaultsManager.shared.birthday, format: "yyyy-MM-dd")
         
-        datePicker.setDate(birthday, animated: true)
+        datePicker.do {
+            $0.preferredDatePickerStyle = .wheels
+            $0.datePickerMode = .date
+            $0.setDate(birthday, animated: true)
+        }
     }
     
     @objc

--- a/PhotoProject/PhotoProject/Present/Profile/LevelViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/LevelViewController.swift
@@ -8,28 +8,41 @@
 import UIKit
 import SnapKit
 
-class LevelViewController: UIViewController {
+class LevelViewController: BaseViewController {
 
     let segmentedControl = UISegmentedControl(items: ["상", "중", "하"])
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureView()
+        
+        
     }
     
-    @objc func okButtonTapped() {
-        print(#function)
-    }
-    
-    func configureView() {
-        navigationItem.title = "레벨"
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인", style: .plain, target: self, action: #selector(okButtonTapped))
-        view.backgroundColor = .white
+    override func setHierarchy() {
         view.addSubview(segmentedControl)
-        segmentedControl.snp.makeConstraints { make in
-            make.centerX.top.equalTo(view.safeAreaLayoutGuide)
-            make.width.equalTo(view.safeAreaLayoutGuide).inset(24)
+    }
+    
+    override func setLayout() {
+        segmentedControl.snp.makeConstraints {
+            $0.centerX.top.equalTo(view.safeAreaLayoutGuide)
+            $0.width.equalTo(view.safeAreaLayoutGuide).inset(24)
         }
+    }
+    
+    override func setStyle() {
+        navigationItem.title = "레벨"
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인",
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(okButtonTapped))
+        view.backgroundColor = .white
+        
+        
         segmentedControl.selectedSegmentIndex = 0
+    }
+    
+    @objc
+    private func okButtonTapped() {
+        
     }
 }

--- a/PhotoProject/PhotoProject/Present/Profile/LevelViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/LevelViewController.swift
@@ -8,13 +8,14 @@
 import UIKit
 import SnapKit
 
-class LevelViewController: BaseViewController {
+final class LevelViewController: BaseViewController {
 
     let segmentedControl = UISegmentedControl(items: ["상", "중", "하"])
     
+    var delegate: LevelDelegateProtocol?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         
     }
     
@@ -30,19 +31,41 @@ class LevelViewController: BaseViewController {
     }
     
     override func setStyle() {
+        view.backgroundColor = .white
+        
         navigationItem.title = "레벨"
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인",
                                                             style: .plain,
                                                             target: self,
                                                             action: #selector(okButtonTapped))
-        view.backgroundColor = .white
         
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "chevron.left"),
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(okButtonTapped))
         
-        segmentedControl.selectedSegmentIndex = 0
+        switch UserDefaultsManager.shared.level {
+        case "상":
+            return segmentedControl.selectedSegmentIndex = 0
+        case "중":
+            return segmentedControl.selectedSegmentIndex = 1
+        case "하":
+            return segmentedControl.selectedSegmentIndex = 2
+        default:
+            return segmentedControl.selectedSegmentIndex = 0
+        }
     }
     
     @objc
     private func okButtonTapped() {
+        let index = segmentedControl.selectedSegmentIndex
+        guard let selectedSegTitle = segmentedControl.titleForSegment(at: index)
+        else { return }
         
+        UserDefaultsManager.shared.level = selectedSegTitle
+        
+        delegate?.setLevelData(levelTitle: selectedSegTitle)
+        
+        navigationController?.popViewController(animated: true)
     }
 }

--- a/PhotoProject/PhotoProject/Present/Profile/LevelViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/LevelViewController.swift
@@ -6,18 +6,14 @@
 //
 
 import UIKit
+
 import SnapKit
 
 final class LevelViewController: BaseViewController {
 
-    let segmentedControl = UISegmentedControl(items: ["상", "중", "하"])
-    
     var delegate: LevelDelegateProtocol?
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-    }
+    private let segmentedControl = UISegmentedControl(items: ["상", "중", "하"])
     
     override func setHierarchy() {
         view.addSubview(segmentedControl)

--- a/PhotoProject/PhotoProject/Present/Profile/LevelViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/LevelViewController.swift
@@ -1,0 +1,35 @@
+//
+//  LevelViewController.swift
+//  PhotoProject
+//
+//  Created by 박신영 on 1/23/25.
+//
+
+import UIKit
+import SnapKit
+
+class LevelViewController: UIViewController {
+
+    let segmentedControl = UISegmentedControl(items: ["상", "중", "하"])
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureView()
+    }
+    
+    @objc func okButtonTapped() {
+        print(#function)
+    }
+    
+    func configureView() {
+        navigationItem.title = "레벨"
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인", style: .plain, target: self, action: #selector(okButtonTapped))
+        view.backgroundColor = .white
+        view.addSubview(segmentedControl)
+        segmentedControl.snp.makeConstraints { make in
+            make.centerX.top.equalTo(view.safeAreaLayoutGuide)
+            make.width.equalTo(view.safeAreaLayoutGuide).inset(24)
+        }
+        segmentedControl.selectedSegmentIndex = 0
+    }
+}

--- a/PhotoProject/PhotoProject/Present/Profile/NicknameViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/NicknameViewController.swift
@@ -43,7 +43,8 @@ final class NicknameViewController: BaseViewController {
         view.backgroundColor = .white
         
         textField.placeholder = "닉네임을 입력해주세요"
-        textField.text = UserDefaultsManager.shared.nickname
+        let nickname = UserDefaultsManager.shared.nickname
+        textField.text = (nickname != "NO NAME") ? nickname : ""
     }
     
     @objc

--- a/PhotoProject/PhotoProject/Present/Profile/NicknameViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/NicknameViewController.swift
@@ -1,0 +1,35 @@
+//
+//  NicknameViewController.swift
+//  PhotoProject
+//
+//  Created by 박신영 on 1/23/25.
+//
+
+import UIKit
+import SnapKit
+
+class NicknameViewController: UIViewController {
+
+    let textField = UITextField()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureView()
+    }
+    
+    @objc func okButtonTapped() {
+        print(#function)
+    }
+    
+    func configureView() {
+        navigationItem.title = "닉네임"
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인", style: .plain, target: self, action: #selector(okButtonTapped))
+        view.backgroundColor = .white
+        view.addSubview(textField)
+        textField.snp.makeConstraints { make in
+            make.centerX.top.equalTo(view.safeAreaLayoutGuide)
+            make.width.equalTo(view.safeAreaLayoutGuide).inset(24)
+        }
+        textField.placeholder = "닉네임을 입력해주세요"
+    }
+}

--- a/PhotoProject/PhotoProject/Present/Profile/NicknameViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/NicknameViewController.swift
@@ -35,9 +35,15 @@ final class NicknameViewController: BaseViewController {
                                                             target: self,
                                                             action: #selector(okButtonTapped))
         
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "chevron.left"),
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(okButtonTapped))
+        
         view.backgroundColor = .white
         
         textField.placeholder = "닉네임을 입력해주세요"
+        textField.text = UserDefaultsManager.shared.nickname
     }
     
     @objc

--- a/PhotoProject/PhotoProject/Present/Profile/NicknameViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/NicknameViewController.swift
@@ -6,16 +6,13 @@
 //
 
 import UIKit
+
 import SnapKit
+import Then
 
 final class NicknameViewController: BaseViewController {
 
     private let textField = UITextField()
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-    }
     
     override func setHierarchy() {
         view.addSubview(textField)
@@ -42,9 +39,11 @@ final class NicknameViewController: BaseViewController {
         
         view.backgroundColor = .white
         
-        textField.placeholder = "닉네임을 입력해주세요"
         let nickname = UserDefaultsManager.shared.nickname
-        textField.text = (nickname != "NO NAME") ? nickname : ""
+        textField.do {
+            $0.placeholder = "닉네임을 입력해주세요"
+            $0.text = (nickname != "NO NAME") ? nickname : ""
+        }
     }
     
     @objc

--- a/PhotoProject/PhotoProject/Present/Profile/NicknameViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/NicknameViewController.swift
@@ -8,28 +8,57 @@
 import UIKit
 import SnapKit
 
-class NicknameViewController: UIViewController {
+final class NicknameViewController: BaseViewController {
 
-    let textField = UITextField()
+    private let textField = UITextField()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureView()
+        
     }
     
-    @objc func okButtonTapped() {
-        print(#function)
-    }
-    
-    func configureView() {
-        navigationItem.title = "닉네임"
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인", style: .plain, target: self, action: #selector(okButtonTapped))
-        view.backgroundColor = .white
+    override func setHierarchy() {
         view.addSubview(textField)
-        textField.snp.makeConstraints { make in
-            make.centerX.top.equalTo(view.safeAreaLayoutGuide)
-            make.width.equalTo(view.safeAreaLayoutGuide).inset(24)
+    }
+    
+    override func setLayout() {
+        textField.snp.makeConstraints {
+            $0.centerX.top.equalTo(view.safeAreaLayoutGuide)
+            $0.width.equalTo(view.safeAreaLayoutGuide).inset(24)
         }
+    }
+    
+    override func setStyle() {
+        navigationItem.title = "닉네임"
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인",
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(okButtonTapped))
+        
+        view.backgroundColor = .white
+        
         textField.placeholder = "닉네임을 입력해주세요"
     }
+    
+    @objc
+    private func okButtonTapped() {
+        print(#function)
+        
+        let text = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        print(text, "text.count")
+        
+        switch text.count >= 2 {
+        case true:
+            UserDefaultsManager.shared.nickname = text
+            NotificationCenter.default.post(name: NSNotification.Name("nickname"),
+                                            object: nil,
+                                            userInfo: ["value": text])
+            
+            navigationController?.popViewController(animated: true)
+        case false:
+            let alert = UIAlertManager.showAlert(title: "닉네임 등록 실패", message: "2글자 이상 입력해주세요")
+            present(alert, animated: true)
+        }
+    }
+    
 }

--- a/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
@@ -18,6 +18,10 @@ final class ProfileViewController: BaseViewController {
     let birthdayLabel = UILabel()
     let levelLabel = UILabel()
     
+    override func viewWillAppear(_ animated: Bool) {
+        nicknameLabel.text = UserDefaultsManager.shared.nickname
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -95,7 +99,7 @@ final class ProfileViewController: BaseViewController {
         birthdayButton.setTitle("생일", for: .normal)
         levelButton.setTitle("레벨", for: .normal)
 
-        nicknameLabel.text = "NO NAME"
+        
         nicknameLabel.textColor = .lightGray
         nicknameLabel.textAlignment = .right
         
@@ -122,6 +126,11 @@ private extension ProfileViewController {
         nicknameButton.addTarget(self, action: #selector(nicknameButtonTapped), for: .touchUpInside)
         birthdayButton.addTarget(self, action: #selector(birthdayButtonTapped), for: .touchUpInside)
         levelButton.addTarget(self, action: #selector(levelButtonTapped), for: .touchUpInside)
+        
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(notificationOn),
+                                               name: NSNotification.Name("nickname"),
+                                               object: nil)
     }
     
     @objc
@@ -143,7 +152,7 @@ private extension ProfileViewController {
     }
 
     @objc
-    private func unSignButtonTapped() {
+    func unSignButtonTapped() {
         print(#function)
         
         UserDefaultsManager.shared.isNotFirstLoading = false
@@ -156,6 +165,16 @@ private extension ProfileViewController {
 
         window.rootViewController = UINavigationController(rootViewController: OnboardingViewController())
         window.makeKeyAndVisible()
+    }
+    
+    @objc
+    func notificationOn(notification: NSNotification) {
+        //이곳에서 값 넣어주기
+        if let name = notification.userInfo!["value"] as? String {
+            nicknameLabel.text = name
+        } else {
+            nicknameLabel.text = "데이터가 안 왔음"
+        }
     }
     
 }

--- a/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
@@ -1,0 +1,108 @@
+//
+//  ProfileViewController.swift
+//  PhotoProject
+//
+//  Created by 박신영 on 1/23/25.
+//
+
+import UIKit
+import SnapKit
+
+class ProfileViewController: UIViewController {
+
+    let nicknameButton = UIButton()
+    let birthdayButton = UIButton()
+    let levelButton = UIButton()
+    
+    let nicknameLabel = UILabel()
+    let birthdayLabel = UILabel()
+    let levelLabel = UILabel()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureView()
+    }
+
+    @objc func okButtonTapped() {
+        print(#function)
+    }
+    
+    func configureView() {
+        navigationItem.title = "프로필 화면"
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "탈퇴하기", style: .plain, target: self, action: #selector(okButtonTapped))
+        view.backgroundColor = .white
+        
+        view.addSubview(nicknameButton)
+        view.addSubview(birthdayButton)
+        view.addSubview(levelButton)
+        
+        view.addSubview(nicknameLabel)
+        view.addSubview(birthdayLabel)
+        view.addSubview(levelLabel)
+        
+        nicknameButton.snp.makeConstraints { make in
+            make.leading.top.equalTo(view.safeAreaLayoutGuide).inset(24)
+            make.height.equalTo(50)
+            make.width.equalTo(100)
+        }
+        
+        birthdayButton.snp.makeConstraints { make in
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(24)
+            make.top.equalTo(nicknameButton.snp.bottom).offset(24)
+            make.height.equalTo(50)
+            make.width.equalTo(100)
+        }
+
+        levelButton.snp.makeConstraints { make in
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(24)
+            make.top.equalTo(birthdayButton.snp.bottom).offset(24)
+            make.height.equalTo(50)
+            make.width.equalTo(100)
+        }
+        
+        nicknameLabel.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(24)
+            make.trailing.equalTo(view.safeAreaLayoutGuide).inset(24)
+            make.leading.equalTo(nicknameButton.snp.trailing).offset(24)
+            make.height.equalTo(50)
+        }
+        
+        birthdayLabel.snp.makeConstraints { make in
+            make.top.equalTo(nicknameLabel.snp.bottom).offset(24)
+            make.trailing.equalTo(view.safeAreaLayoutGuide).inset(24)
+            make.leading.equalTo(birthdayButton.snp.trailing).offset(24)
+            make.height.equalTo(50)
+        }
+
+        levelLabel.snp.makeConstraints { make in
+            make.top.equalTo(birthdayLabel.snp.bottom).offset(24)
+            make.trailing.equalTo(view.safeAreaLayoutGuide).inset(24)
+            make.leading.equalTo(levelButton.snp.trailing).offset(24)
+            make.height.equalTo(50)
+        }
+
+        
+        
+        nicknameButton.setTitleColor(.black, for: .normal)
+        birthdayButton.setTitleColor(.black, for: .normal)
+        levelButton.setTitleColor(.black, for: .normal)
+        
+        nicknameButton.setTitle("닉네임", for: .normal)
+        birthdayButton.setTitle("생일", for: .normal)
+        levelButton.setTitle("레벨", for: .normal)
+
+        nicknameLabel.text = "NO NAME"
+        nicknameLabel.textColor = .lightGray
+        nicknameLabel.textAlignment = .right
+        
+        birthdayLabel.text = "NO DATE"
+        birthdayLabel.textColor = .lightGray
+        birthdayLabel.textAlignment = .right
+        
+        levelLabel.text = "NO LEVEL"
+        levelLabel.textColor = .lightGray
+        levelLabel.textAlignment = .right
+    }
+    
+ 
+}

--- a/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import SnapKit
 
-class ProfileViewController: UIViewController {
+final class ProfileViewController: BaseViewController {
 
     let nicknameButton = UIButton()
     let birthdayButton = UIButton()
@@ -20,68 +20,70 @@ class ProfileViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureView()
-    }
-
-    @objc func okButtonTapped() {
-        print(#function)
+        
     }
     
-    func configureView() {
-        navigationItem.title = "프로필 화면"
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "탈퇴하기", style: .plain, target: self, action: #selector(okButtonTapped))
+    override func setHierarchy() {
+        view.addSubviews(nicknameButton,
+                         birthdayButton,
+                         levelButton,
+                         nicknameLabel,
+                         birthdayLabel,
+                         levelLabel)
+    }
+    
+    override func setLayout() {
+        nicknameButton.snp.makeConstraints {
+            $0.leading.top.equalTo(view.safeAreaLayoutGuide).inset(24)
+            $0.height.equalTo(50)
+            $0.width.equalTo(100)
+        }
+        
+        birthdayButton.snp.makeConstraints {
+            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(24)
+            $0.top.equalTo(nicknameButton.snp.bottom).offset(24)
+            $0.height.equalTo(50)
+            $0.width.equalTo(100)
+        }
+
+        levelButton.snp.makeConstraints {
+            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(24)
+            $0.top.equalTo(birthdayButton.snp.bottom).offset(24)
+            $0.height.equalTo(50)
+            $0.width.equalTo(100)
+        }
+        
+        nicknameLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(24)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide).inset(24)
+            $0.leading.equalTo(nicknameButton.snp.trailing).offset(24)
+            $0.height.equalTo(50)
+        }
+        
+        birthdayLabel.snp.makeConstraints {
+            $0.top.equalTo(nicknameLabel.snp.bottom).offset(24)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide).inset(24)
+            $0.leading.equalTo(birthdayButton.snp.trailing).offset(24)
+            $0.height.equalTo(50)
+        }
+
+        levelLabel.snp.makeConstraints {
+            $0.top.equalTo(birthdayLabel.snp.bottom).offset(24)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide).inset(24)
+            $0.leading.equalTo(levelButton.snp.trailing).offset(24)
+            $0.height.equalTo(50)
+        }
+
+    }
+    
+    override func setStyle() {
         view.backgroundColor = .white
         
-        view.addSubview(nicknameButton)
-        view.addSubview(birthdayButton)
-        view.addSubview(levelButton)
-        
-        view.addSubview(nicknameLabel)
-        view.addSubview(birthdayLabel)
-        view.addSubview(levelLabel)
-        
-        nicknameButton.snp.makeConstraints { make in
-            make.leading.top.equalTo(view.safeAreaLayoutGuide).inset(24)
-            make.height.equalTo(50)
-            make.width.equalTo(100)
-        }
-        
-        birthdayButton.snp.makeConstraints { make in
-            make.leading.equalTo(view.safeAreaLayoutGuide).offset(24)
-            make.top.equalTo(nicknameButton.snp.bottom).offset(24)
-            make.height.equalTo(50)
-            make.width.equalTo(100)
-        }
-
-        levelButton.snp.makeConstraints { make in
-            make.leading.equalTo(view.safeAreaLayoutGuide).offset(24)
-            make.top.equalTo(birthdayButton.snp.bottom).offset(24)
-            make.height.equalTo(50)
-            make.width.equalTo(100)
-        }
-        
-        nicknameLabel.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).offset(24)
-            make.trailing.equalTo(view.safeAreaLayoutGuide).inset(24)
-            make.leading.equalTo(nicknameButton.snp.trailing).offset(24)
-            make.height.equalTo(50)
-        }
-        
-        birthdayLabel.snp.makeConstraints { make in
-            make.top.equalTo(nicknameLabel.snp.bottom).offset(24)
-            make.trailing.equalTo(view.safeAreaLayoutGuide).inset(24)
-            make.leading.equalTo(birthdayButton.snp.trailing).offset(24)
-            make.height.equalTo(50)
-        }
-
-        levelLabel.snp.makeConstraints { make in
-            make.top.equalTo(birthdayLabel.snp.bottom).offset(24)
-            make.trailing.equalTo(view.safeAreaLayoutGuide).inset(24)
-            make.leading.equalTo(levelButton.snp.trailing).offset(24)
-            make.height.equalTo(50)
-        }
-
-        
+        navigationItem.title = "프로필 화면"
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "탈퇴하기",
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(unSignButtonTapped))
         
         nicknameButton.setTitleColor(.black, for: .normal)
         birthdayButton.setTitleColor(.black, for: .normal)
@@ -103,6 +105,21 @@ class ProfileViewController: UIViewController {
         levelLabel.textColor = .lightGray
         levelLabel.textAlignment = .right
     }
+
+    @objc
+    private func unSignButtonTapped() {
+        print(#function)
+        
+        UserDefaultsManager.shared.isNotFirstLoading = false
+        print("UserDefaultsManager.shared.isNotFirstLoading: \(UserDefaultsManager.shared.isNotFirstLoading)")
+        
+        //rootVC 탭바VC로 변경
+        guard let windowScene =  UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = windowScene.windows.first
+        else { return }
+
+        window.rootViewController = UINavigationController(rootViewController: OnboardingViewController())
+        window.makeKeyAndVisible()
+    }
     
- 
 }

--- a/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
@@ -21,6 +21,8 @@ final class ProfileViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setDelegate()
+        setAddTarget()
     }
     
     override func setHierarchy() {
@@ -104,6 +106,40 @@ final class ProfileViewController: BaseViewController {
         levelLabel.text = "NO LEVEL"
         levelLabel.textColor = .lightGray
         levelLabel.textAlignment = .right
+    }
+    
+    
+    
+}
+
+private extension ProfileViewController {
+    
+    private func setDelegate() {
+        
+    }
+    
+    private func setAddTarget() {
+        nicknameButton.addTarget(self, action: #selector(nicknameButtonTapped), for: .touchUpInside)
+        birthdayButton.addTarget(self, action: #selector(birthdayButtonTapped), for: .touchUpInside)
+        levelButton.addTarget(self, action: #selector(levelButtonTapped), for: .touchUpInside)
+    }
+    
+    @objc
+    private func nicknameButtonTapped() {
+        print(#function)
+        viewTransition(viewController: NicknameViewController(), transitionStyle: .push)
+    }
+    
+    @objc
+    private func birthdayButtonTapped() {
+        print(#function)
+        viewTransition(viewController: BirthdayViewController(), transitionStyle: .push)
+    }
+    
+    @objc
+    private func levelButtonTapped() {
+        print(#function)
+        viewTransition(viewController: LevelViewController(), transitionStyle: .push)
     }
 
     @objc

--- a/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
@@ -9,6 +9,9 @@ import UIKit
 import SnapKit
 
 final class ProfileViewController: BaseViewController {
+    
+    let nickname: String?
+    let birthday: String?
 
     let nicknameButton = UIButton()
     let birthdayButton = UIButton()
@@ -18,8 +21,19 @@ final class ProfileViewController: BaseViewController {
     let birthdayLabel = UILabel()
     let levelLabel = UILabel()
     
+    init(nickname: String, birthday: String) {
+        self.nickname = nickname
+        self.birthday = birthday
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewWillAppear(_ animated: Bool) {
-        nicknameLabel.text = UserDefaultsManager.shared.nickname
+        
     }
     
     override func viewDidLoad() {
@@ -83,6 +97,9 @@ final class ProfileViewController: BaseViewController {
     }
     
     override func setStyle() {
+        nicknameLabel.text = nickname
+        birthdayLabel.text = birthday
+        
         view.backgroundColor = .white
         
         navigationItem.title = "프로필 화면"
@@ -103,7 +120,6 @@ final class ProfileViewController: BaseViewController {
         nicknameLabel.textColor = .lightGray
         nicknameLabel.textAlignment = .right
         
-        birthdayLabel.text = "NO DATE"
         birthdayLabel.textColor = .lightGray
         birthdayLabel.textAlignment = .right
         
@@ -142,7 +158,11 @@ private extension ProfileViewController {
     @objc
     private func birthdayButtonTapped() {
         print(#function)
-        viewTransition(viewController: BirthdayViewController(), transitionStyle: .push)
+        let vc = BirthdayViewController()
+        vc.onChange = { birthday in
+            self.birthdayLabel.text = birthday
+        }
+        viewTransition(viewController: vc, transitionStyle: .push)
     }
     
     @objc

--- a/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
@@ -10,20 +10,23 @@ import SnapKit
 
 final class ProfileViewController: BaseViewController {
     
-    let nickname: String?
-    let birthday: String?
+    let nickname: String
+    let birthday: String
+    let level: String
 
     let nicknameButton = UIButton()
     let birthdayButton = UIButton()
     let levelButton = UIButton()
+    let saveButton = UIButton()
     
     let nicknameLabel = UILabel()
     let birthdayLabel = UILabel()
     let levelLabel = UILabel()
     
-    init(nickname: String, birthday: String) {
+    init(nickname: String, birthday: String, level: String) {
         self.nickname = nickname
         self.birthday = birthday
+        self.level = level
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -33,13 +36,14 @@ final class ProfileViewController: BaseViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        
+        saveButtonStateUI()
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setDelegate()
+        
+        
         setAddTarget()
     }
     
@@ -49,7 +53,8 @@ final class ProfileViewController: BaseViewController {
                          levelButton,
                          nicknameLabel,
                          birthdayLabel,
-                         levelLabel)
+                         levelLabel,
+                         saveButton)
     }
     
     override func setLayout() {
@@ -93,10 +98,17 @@ final class ProfileViewController: BaseViewController {
             $0.leading.equalTo(levelButton.snp.trailing).offset(24)
             $0.height.equalTo(50)
         }
+        
+        saveButton.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(30)
+            $0.horizontalEdges.equalToSuperview().inset(40)
+            $0.height.equalTo(60)
+        }
 
     }
     
     override func setStyle() {
+        levelLabel.text = level
         nicknameLabel.text = nickname
         birthdayLabel.text = birthday
         
@@ -123,25 +135,22 @@ final class ProfileViewController: BaseViewController {
         birthdayLabel.textColor = .lightGray
         birthdayLabel.textAlignment = .right
         
-        levelLabel.text = "NO LEVEL"
         levelLabel.textColor = .lightGray
         levelLabel.textAlignment = .right
+        
+        saveButton.setTitle("저장하기", for: .normal)
+        saveButton.setTitleColor(.black, for: .normal)
     }
-    
-    
     
 }
 
 private extension ProfileViewController {
     
-    private func setDelegate() {
-        
-    }
-    
-    private func setAddTarget() {
+    func setAddTarget() {
         nicknameButton.addTarget(self, action: #selector(nicknameButtonTapped), for: .touchUpInside)
         birthdayButton.addTarget(self, action: #selector(birthdayButtonTapped), for: .touchUpInside)
         levelButton.addTarget(self, action: #selector(levelButtonTapped), for: .touchUpInside)
+        saveButton.addTarget(self, action: #selector(saveButtonTapped), for: .touchUpInside)
         
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(notificationOn),
@@ -149,14 +158,28 @@ private extension ProfileViewController {
                                                object: nil)
     }
     
+    func saveButtonStateUI() {
+        let name = UserDefaultsManager.shared.nickname
+        let birthday = UserDefaultsManager.shared.birthday
+        let level = UserDefaultsManager.shared.level
+        
+        let flag = [name,birthday,level].allSatisfy {
+            !["NO NAME", "NO DATE", "NO LEVEL"].contains($0)
+        }
+        
+        saveButton.backgroundColor = flag ? .blue : .lightGray
+        let titleColor: UIColor = flag ? .white : .black
+        saveButton.setTitleColor(titleColor, for: .normal)
+    }
+    
     @objc
-    private func nicknameButtonTapped() {
+    func nicknameButtonTapped() {
         print(#function)
         viewTransition(viewController: NicknameViewController(), transitionStyle: .push)
     }
     
     @objc
-    private func birthdayButtonTapped() {
+    func birthdayButtonTapped() {
         print(#function)
         let vc = BirthdayViewController()
         vc.onChange = { birthday in
@@ -166,9 +189,19 @@ private extension ProfileViewController {
     }
     
     @objc
-    private func levelButtonTapped() {
+    func levelButtonTapped() {
         print(#function)
-        viewTransition(viewController: LevelViewController(), transitionStyle: .push)
+        let vc = LevelViewController()
+        vc.delegate = self
+        viewTransition(viewController: vc, transitionStyle: .push)
+    }
+    
+    @objc
+    func saveButtonTapped() {
+        print(#function)
+        
+        let alert = UIAlertManager.showAlert(title: "저장 성공", message: "🎉축하합니다🎉")
+        present(alert, animated: true)
     }
 
     @objc
@@ -189,12 +222,20 @@ private extension ProfileViewController {
     
     @objc
     func notificationOn(notification: NSNotification) {
-        //이곳에서 값 넣어주기
         if let name = notification.userInfo!["value"] as? String {
             nicknameLabel.text = name
         } else {
             nicknameLabel.text = "데이터가 안 왔음"
         }
+    }
+    
+}
+
+extension ProfileViewController: LevelDelegateProtocol {
+    
+    func setLevelData(levelTitle: String) {
+        print(#function)
+        levelLabel.text = levelTitle
     }
     
 }

--- a/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
+++ b/PhotoProject/PhotoProject/Present/Profile/ProfileViewController.swift
@@ -6,7 +6,9 @@
 //
 
 import UIKit
+
 import SnapKit
+import Then
 
 final class ProfileViewController: BaseViewController {
     
@@ -14,14 +16,14 @@ final class ProfileViewController: BaseViewController {
     let birthday: String
     let level: String
 
-    let nicknameButton = UIButton()
-    let birthdayButton = UIButton()
-    let levelButton = UIButton()
-    let saveButton = UIButton()
+    private let nicknameButton = UIButton()
+    private let birthdayButton = UIButton()
+    private let levelButton = UIButton()
+    private let saveButton = UIButton()
     
-    let nicknameLabel = UILabel()
-    let birthdayLabel = UILabel()
-    let levelLabel = UILabel()
+    private let nicknameLabel = UILabel()
+    private let birthdayLabel = UILabel()
+    private let levelLabel = UILabel()
     
     init(nickname: String, birthday: String, level: String) {
         self.nickname = nickname
@@ -41,8 +43,6 @@ final class ProfileViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        
         
         setAddTarget()
     }
@@ -120,26 +120,42 @@ final class ProfileViewController: BaseViewController {
                                                             target: self,
                                                             action: #selector(unSignButtonTapped))
         
-        nicknameButton.setTitleColor(.black, for: .normal)
-        birthdayButton.setTitleColor(.black, for: .normal)
-        levelButton.setTitleColor(.black, for: .normal)
+        nicknameButton.do {
+            $0.setTitleColor(.black, for: .normal)
+            $0.setTitle("닉네임", for: .normal)
+        }
         
-        nicknameButton.setTitle("닉네임", for: .normal)
-        birthdayButton.setTitle("생일", for: .normal)
-        levelButton.setTitle("레벨", for: .normal)
+        birthdayButton.do {
+            $0.setTitleColor(.black, for: .normal)
+            $0.setTitle("생일", for: .normal)
+        }
+        
+        levelButton.do {
+            $0.setTitleColor(.black, for: .normal)
+            $0.setTitle("레벨", for: .normal)
+        }
+        
+        saveButton.do {
+            $0.setTitle("저장하기", for: .normal)
+            $0.titleLabel?.font = .boldSystemFont(ofSize: 16)
+            $0.layer.cornerRadius = 10
+            $0.layer.borderWidth = 3
+        }
 
+        nicknameLabel.do {
+            $0.textColor = .lightGray
+            $0.textAlignment = .right
+        }
         
-        nicknameLabel.textColor = .lightGray
-        nicknameLabel.textAlignment = .right
+        birthdayLabel.do {
+            $0.textColor = .lightGray
+            $0.textAlignment = .right
+        }
         
-        birthdayLabel.textColor = .lightGray
-        birthdayLabel.textAlignment = .right
-        
-        levelLabel.textColor = .lightGray
-        levelLabel.textAlignment = .right
-        
-        saveButton.setTitle("저장하기", for: .normal)
-        saveButton.setTitleColor(.black, for: .normal)
+        levelLabel.do {
+            $0.textColor = .lightGray
+            $0.textAlignment = .right
+        }
     }
     
 }
@@ -167,9 +183,10 @@ private extension ProfileViewController {
             !["NO NAME", "NO DATE", "NO LEVEL"].contains($0)
         }
         
-        saveButton.backgroundColor = flag ? .blue : .lightGray
         let titleColor: UIColor = flag ? .white : .black
         saveButton.setTitleColor(titleColor, for: .normal)
+        saveButton.backgroundColor = flag ? .systemBlue.withAlphaComponent(1.0) : .lightGray.withAlphaComponent(0.6)
+        saveButton.layer.borderColor = flag ? UIColor.green.cgColor : UIColor.clear.cgColor
     }
     
     @objc
@@ -208,7 +225,11 @@ private extension ProfileViewController {
     func unSignButtonTapped() {
         print(#function)
         
-        UserDefaultsManager.shared.isNotFirstLoading = false
+        //Reset UserDefaults
+        if let bundleID = Bundle.main.bundleIdentifier {
+           UserDefaults.standard.removePersistentDomain(forName: bundleID)
+        }
+        
         print("UserDefaultsManager.shared.isNotFirstLoading: \(UserDefaultsManager.shared.isNotFirstLoading)")
         
         //rootVC 탭바VC로 변경


### PR DESCRIPTION
## Related Issues 💭
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #19 

## What is the PR? 🔍
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
- 22회차 DailyTask를 구현합니다.


## Changes 📝
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
- ### [시작화면 제어하기]
  - [x] 최초 앱 빌드 시 OnboardingVC를 첫 화면으로 설정
  - [x] `시작하기 버튼` 클릭 시 PhotoTopic으로 이동
  - [x] PhotoTopic 우측 상단 탭 -> ProfileVC로 이동
  - [x] ProfileVC `탈퇴하기 버튼` 클릭 시 다시 OnboardingVC로 이동
  - [x] 최초 앱 빌드가 아닐 시 TopicVC로 그대로 진행
- ### [값 전달 실습하기]
  - [x] ProfileVC 에서 닉네임, 생일, 레벨 버튼을 누르면 각각 뷰컨트롤러가 Push
  - [x] NicknameVC에 값을 입력하고확인 버튼을 누르거나, 백버튼을 누르면 값 전달. 전달된 값은 ProfileVC 의 닉네임 레이블에 표시
  - [x] 만약 ProfileVC 닉네임 레이블에 값이 반영된 상황에서 닉네임 버튼을 누르면, NicknameVC 텍스트필드에 기존 데이터를 반영해서 표시
  - [x] 생일과 레벨 부분도 닉네임처럼 동일한 동작으로 구현
  - [x] 닉네임, 생일, 레벨 3개의 값이 모두 입력된 경우, ProfileVC 의 저장하기 버튼을 누를 수 있고, 저장하기 버튼을 클릭하면 영구적으로 저장된 값이 유지되도록 설정

## Screenshot 📷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    기능    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/081f9d06-bb40-4594-a5d4-2186c147b133" width ="200">|

## To Do 🙏
<!-- 보완해야할 것. -->
- photoDetailModelDataSet() 매개변수 별 함수로 분리하기
- BaseView Custom init 사용하여 setLayout 함수 overide 시점 분기처리
- PhotoDetailView layoutIfNeed 및 Snakit remake, update 관련 자료 찾고 적용하기
- 탈퇴하고, onboardingVC에서 시작버튼 탭 이후 PhotoTopic View로 돌아왔을 때 상단 네비게이션 파트가 조금 주저 앉는 상황

|    기존    |   스크린샷   |    에러상황    |   스크린샷   |
| :-------------: | :----------: | :-------------: | :----------: |
| PNG | <img src = "https://github.com/user-attachments/assets/6e27f36d-be11-439a-af51-bc499adf1a11" width ="200">| PNG | <img src = "https://github.com/user-attachments/assets/159e25f4-8b88-45fb-9548-57c62638c12d" width ="200">|

